### PR TITLE
fixed bug with changes to _MotionCorrectedSequence __init__

### DIFF
--- a/sima/sequence.py
+++ b/sima/sequence.py
@@ -711,22 +711,6 @@ class _MotionCorrectedSequence(_WrapperSequence):
             'extent': self._frame_shape[:3],
         }
 
-    # Need to define in this class to accommodate argument change in __init__
-    # 'frame_shape' is no longer a required __init__ argument in SIMA v1.
-    @classmethod
-    def _from_dict(cls, d, savedir=None):
-        base_dict = d.pop('base')
-        base_class = base_dict.pop('__class__')
-        base = base_class._from_dict(base_dict, savedir)
-        try:
-            return cls(base, **d)
-        except TypeError:
-            if 'frame_shape' in d:
-                d.pop('frame_shape')
-                return cls(base, **d)
-            else:
-                raise Exception('Error import motion corrected sequence')
-
 
 class _MaskedSequence(_WrapperSequence):
     """Sequence for masking invalid data with NaN's.


### PR DESCRIPTION
a couple bug fixes in the new 'extent' argument

handling TypeError that arises when loading old datasets containing frame_shape argument (no longer necessary with the 'extent' argument)
