### PR TITLE
Fix to allow sima 1.x to handle sima 0.x time_averages.pkl

### DIFF
--- a/examples/transform_rois.py
+++ b/examples/transform_rois.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+"""Example ROI transform script
+
+To transform ROIs from a source dataset to target datasets:
+>> python transform_rois.py /path/to/source/dataset /path/to/target/datasets
+    SOURCE_LABEL
+
+For help and additional arguments:
+>> python transform_rois.py --help
+
+"""
+
+import os
+import argparse
+
+from sima import ImagingDataset
+from sima.misc import TransformError
+
+if __name__ == '__main__':
+    """Calculate an affine transform between the source dataset and all
+    datasets within the target directory.
+    Apply this transform to all ROIs in the SOURCE_LABEL ROIList and copy them
+    to the target datasets.
+    Auto-generated ROILists are saved with the TARGET_LABEL label"""
+
+    argParser = argparse.ArgumentParser()
+
+    argParser.add_argument(
+        "source", action="store", type=str,
+        help="Source SIMA directory for the ROIs")
+    argParser.add_argument(
+        "target", action="store", type=str,
+        help="Target path to locate SIMA directories to copy ROIs to")
+    argParser.add_argument(
+        "source_label", action="store", type=str,
+        help="ROIList label for the ROIs to be copied")
+    argParser.add_argument(
+        "-l", "--target_label", action="store", type=str,
+        default="auto_transformed",
+        help="Label to give the new transformed ROIs")
+    argParser.add_argument(
+        "-c", "--channel", action="store", type=str, default="0",
+        help="Channel of the datasets used to calculate the affine transform")
+    argParser.add_argument(
+        "-C", "--copy_properties", action="store_true",
+        help="Copy ROI properties ")
+    argParser.add_argument(
+        "-o", "--overwrite", action="store_true",
+        help="If target_label already exists, overwrite")
+    args = argParser.parse_args()
+
+    source_dataset = ImagingDataset.load(args.source)
+    print "Beginning ROI transforms, source dataset: ", args.source
+    print "-----------------------------------------"
+
+    for directory, folders, files in os.walk(args.target):
+        if directory.endswith('.sima'):
+            try:
+                target_dataset = ImagingDataset.load(directory)
+            except IOError:
+                continue
+
+            if os.path.samefile(args.source, directory):
+                continue
+
+            if args.target_label in target_dataset.ROIs and not args.overwrite:
+                print "Label already exists, skipping: ", directory
+                continue
+
+            try:
+                channel = int(args.channel)
+            except ValueError:
+                channel = args.channel
+
+            try:
+                target_dataset.import_transformed_ROIs(
+                    source_dataset=source_dataset,
+                    source_channel=channel,
+                    target_channel=channel,
+                    source_label=args.source_label,
+                    target_label=args.target_label,
+                    copy_properties=args.copy_properties)
+            except TransformError:
+                print "FAIL, transform error: ", directory
+            else:
+                print "SUCCESS, ROIs transformed:", directory

--- a/sima/ROI.py
+++ b/sima/ROI.py
@@ -340,26 +340,29 @@ class ROIList(list):
         else:
             raise ValueError('Unrecognized file format.')
 
-    def transform(self, transforms, copy_properties=True):
+    def transform(self, transforms, im_shape=None, copy_properties=True):
         """Apply 2x3 affine transformations to the ROIs
 
         Parameters
         ----------
         transforms : list of 2x3 Numpy arrays
             The affine transformations to be applied to the ROIs.  Length of
-            list should equal the number of planes (im_shape[0])
+            list should equal the number of planes (im_shape[0]).
+
+        im_shape : 3-element tuple, optional
+            The (zyx) shape of the target image. If None, must be set before
+            any ROI can be converted to a mask.
 
         copy_properties : bool, optional
-            Copy the label, id, tags, and im_shape properties from the source
-            ROIs to the transformed ROIs
+            Copy the label, id, and tags properties from the source
+            ROIs to the transformed ROIs.
 
         Returns
         -------
         sima.ROI.ROIList
             Returns an ROIList consisting of the transformed ROI objects.
+
         """
-        # This should still work if im_shape is None
-        # assert len(transforms) == self[0].im_shape[0]
         transformed_rois = []
         for roi in self:
             transformed_polygons = []
@@ -371,12 +374,12 @@ class ROIList(list):
                 transformed_coords = [np.hstack((coords, z)) for coords in
                                       transformed_coords]
                 transformed_polygons.append(transformed_coords)
-            transformed_roi = ROI(polygons=transformed_polygons)
+            transformed_roi = ROI(
+                polygons=transformed_polygons, im_shape=im_shape)
             if copy_properties:
                 transformed_roi.label = roi.label
                 transformed_roi.id = roi.id
                 transformed_roi.tags = roi.tags
-                transformed_roi.im_shape = roi.im_shape
             transformed_rois.append(transformed_roi)
         return ROIList(rois=transformed_rois)
 

--- a/sima/imaging.py
+++ b/sima/imaging.py
@@ -329,6 +329,7 @@ class ImagingDataset(object):
         copy_properties : bool, optional
             Copy the label, id, tags, and im_shape properties from the source
             ROIs to the transformed ROIs
+
         """
 
         source_channel = source_dataset._resolve_channel(source_channel)
@@ -344,7 +345,8 @@ class ImagingDataset(object):
             source_label = most_recent_key(src_rois)
         src_rois = src_rois[source_label]
         transformed_ROIs = src_rois.transform(
-            transforms, copy_properties=copy_properties)
+            transforms, im_shape=self.frame_shape[:3],
+            copy_properties=copy_properties)
         self.add_ROIs(transformed_ROIs, label=target_label)
 
     def delete_ROIs(self, label):

--- a/sima/misc/__init__.py
+++ b/sima/misc/__init__.py
@@ -15,6 +15,10 @@ else:
     cv2_available = LooseVersion(cv2.__version__) >= LooseVersion('2.4.8')
 
 
+class TransformError(Exception):
+    pass
+
+
 def lazyprop(fn):
     """Like property, but only computes on first call."""
     attr_name = '_lazy_' + fn.__name__
@@ -117,9 +121,6 @@ def affine_transform(source, target):
     """
     if not cv2_available:
         raise ImportError('OpenCV >= 2.4.8 required')
-
-    class TransformError(Exception):
-        pass
 
     slice_ = tuple(slice(0, min(source.shape[i], target.shape[i]))
                    for i in range(2))


### PR DESCRIPTION
time_averages.pkl will just be ignored if its loaded and it looks like it was saved with sima 0.x (a list of arrays instead of a single 4D array).

dataset.time_averages works fine now, but time_averages.pkl will not be updated if you load a read-only 0.x set with sima 1.x, so every time you call dataset.time_averages it will need to be re-calculated which can be slow. 

Should dataset.time_averages warn the user that it tried to save time_averages.pkl, but the read_only flag was set?

Should we add an 0.x to 1.x example script to sima?