### PR TITLE
Sequence refactor

### DIFF
--- a/ROI_BuddyUI/roi_buddy.py
+++ b/ROI_BuddyUI/roi_buddy.py
@@ -330,46 +330,46 @@ class RoiBuddy(QMainWindow, Ui_ROI_Buddy):
 
     def connectSignals(self):
 
-        #toggle the edit or align mdoe
+        # toggle the edit or align mdoe
         self.modeSelection.buttonClicked.connect(self.toggle_mode)
 
-        #buttons for adding and removing t-series from list
+        # buttons for adding and removing t-series from list
         self.add_tseries_button.clicked.connect(self.add_tseries)
         self.remove_tseries_button.clicked.connect(self.remove_tseries)
 
-        #selection in tSeries_list changes
+        # selection in tSeries_list changes
         self.tSeries_list.currentItemChanged.connect(
             self.toggle_active_tSeries)
 
-        #toggle the active roi set
+        # toggle the active roi set
         self.active_rois_combobox.activated.connect(self.toggle_rois)
 
-        #add/delete roi sets
+        # add/delete roi sets
         self.new_set_button.clicked.connect(self.new_roi_set)
         self.delete_set_button.clicked.connect(self.delete_roi_set)
 
-        #z-plane selection
+        # z-plane selection
         self.plane_index_box.valueChanged.connect(self.toggle_plane)
 
-        #Channel selection
+        # Channel selection
         self.baseImage_list.activated.connect(self.toggle_base_image)
         self.processed_checkbox.clicked.connect(self.toggle_base_image)
 
-        #show/hide ROIs
+        # show/hide ROIs
         self.show_ROIs_checkbox.stateChanged.connect(self.toggle_show_rois)
         self.show_all_checkbox.stateChanged.connect(self.toggle_show_all)
 
-        #save ROIs buttons
+        # save ROIs buttons
         self.save_current_rois_button.clicked.connect(
             lambda: self.save([self.tSeries_list.currentItem()]))
 
-        #Run registration
+        # Run registration
         self.register_rois_button.clicked.connect(self.register_rois)
 
-        #Propagate tags
+        # Propagate tags
         self.propagate_tags_button.clicked.connect(self.propagate_tags)
 
-        #Import transformed ROIs
+        # Import transformed ROIs
         self.import_rois_button.clicked.connect(self.import_rois)
 
     def closeEvent(self, event):
@@ -393,19 +393,19 @@ class RoiBuddy(QMainWindow, Ui_ROI_Buddy):
         Configure the main display window with a guiqwt ImageDialog object
         """
 
-        #initialize the viewer
+        # initialize the viewer
         viewer = ImageDialog(edit=False, toolbar=True,
                              wintitle='Experiment Image Display')
-        #Add the freeform tool
+        # Add the freeform tool
         viewer.add_tool(FreeFormTool)
         viewer.add_tool(EllipseTool)
         viewer.add_tool(RectangleTool)
-        #Remove the grid from the item list manager
+        # Remove the grid from the item list manager
         viewer.get_plot().get_items()[0].set_private(True)
-        #add viewer to the display frame layout
+        # add viewer to the display frame layout
         self.displayFrame.layout().addWidget(viewer)
 
-        #remove useless buttons
+        # remove useless buttons
         for i in range(3, 18)[::-1]:
             viewer.toolbar.removeAction(viewer.toolbar.actions()[i])
 
@@ -440,7 +440,7 @@ class RoiBuddy(QMainWindow, Ui_ROI_Buddy):
 
     def initialize_roi_manager(self):
 
-        #add the ROI manager to the roiListFame
+        # add the ROI manager to the roiListFame
         itemListPanel = self.viewer.get_itemlist_panel()
         layout = QGridLayout()
 
@@ -448,13 +448,13 @@ class RoiBuddy(QMainWindow, Ui_ROI_Buddy):
         self.itemListFrame.setLayout(layout)
         itemListPanel.show()
 
-        #This is the ROI manager toolbar
+        # This is the ROI manager toolbar
         toolbar = itemListPanel.findChild(QToolBar)
 
-        #remove the default delete actions -- doesn't work with freeform tool
+        # remove the default delete actions -- doesn't work with freeform tool
         toolbar.removeAction(toolbar.actions()[-1])
 
-        #adding actions to the ROI manager toolbar
+        # adding actions to the ROI manager toolbar
         toolbar.addAction(self.delete_action)
         toolbar.addAction(self.edit_label_action)
         toolbar.addAction(self.add_tags_action)
@@ -482,7 +482,7 @@ class RoiBuddy(QMainWindow, Ui_ROI_Buddy):
         contrastPanel.show()
 
     def toggle_button_state(self, enabled=True):
-        #for when there are no t-series in the list
+        # for when there are no t-series in the list
         self.remove_tseries_button.setEnabled(enabled)
 
         self.active_rois_combobox.clear()
@@ -1908,7 +1908,7 @@ class UI_tSeries(QListWidgetItem):
             if name in rois_by_label:
                 # If two ROIs have the same name they'll have the same
                 # tags and id, so no need to check here
-                #TODO: ensure that this is true
+                # TODO: ensure that this is true
                 rois_by_label[name]['polygons'].extend(verts)
             else:
                 rois_by_label[name] = {}
@@ -1925,8 +1925,9 @@ class UI_tSeries(QListWidgetItem):
                             id=rois_by_label[label]['id'],
                             label=rois_by_label[label]['label']))
 
-        ROIs.save(path=join(self.dataset.savedir, 'rois.pkl'),
-                  label=roi_set_name)
+        self.dataset.add_ROIs(ROIs, label=roi_set_name)
+        # ROIs.save(path=join(self.dataset.savedir, 'rois.pkl'),
+        #           label=roi_set_name)
 
 
 class UI_ROI(PolygonShape, ROI):
@@ -2109,7 +2110,7 @@ class ImportROIsWidget(QDialog, Ui_importROIsWidget):
 
         self.parent = parent
 
-        #initialize source imaging datasets
+        # initialize source imaging datasets
         self.initialize_form()
 
     def initialize_form(self):

--- a/ROI_BuddyUI/roi_buddy.py
+++ b/ROI_BuddyUI/roi_buddy.py
@@ -1859,10 +1859,10 @@ class UI_tSeries(QListWidgetItem):
                     mask = np.zeros(self.parent.base_im.data.shape, dtype=bool)
                     for x in np.arange(
                             np.floor(center[0] - radius),
-                            np.ceil(center[0] + radius)):
+                            np.ceil(center[0] + radius)).astype(int):
                         for y in np.arange(
                                 np.floor(center[1] - radius),
-                                np.ceil(center[1] + radius)):
+                                np.ceil(center[1] + radius)).astype(int):
 
                             d = np.linalg.norm(
                                 np.array((x, y)) - np.array(center))
@@ -1874,7 +1874,7 @@ class UI_tSeries(QListWidgetItem):
 
                     points = np.array(poly[0].exterior.coords)[:, :2]
                     new_roi = UI_ROI(self, points, id=None,
-                                     label=parent.next_label(), tags=None)
+                                     label=self.next_label(), tags=None)
                     self.parent.plot.del_item(item)
                     self.parent.plot.add_item(new_roi)
                 else:

--- a/sima/imaging.py
+++ b/sima/imaging.py
@@ -289,7 +289,7 @@ class ImagingDataset(object):
             ds._read_only = True
             return ds
 
-    def _todict(self, savedir):
+    def _todict(self):
         """Returns the dataset as a dictionary, useful for saving"""
         return {'savedir': abspath(self.savedir),
                 'channel_names': self.channel_names,
@@ -663,9 +663,12 @@ class ImagingDataset(object):
         if self._read_only:
             raise Exception('Cannot save read-only dataset.  Change savedir ' +
                             'to a new directory')
+        # Keep this out side the with statement
+        # If sequences haven't been loaded yet, need to read sequences.pkl
+        sequences = [seq._todict(savedir) for seq in self.sequences]
         with open(join(savedir, 'sequences.pkl'), 'wb') as f:
-            pickle.dump([seq._todict(savedir) for seq in self.sequences],
-                        f, pickle.HIGHEST_PROTOCOL)
+            pickle.dump(sequences, f, pickle.HIGHEST_PROTOCOL)
+
         with open(join(savedir, 'dataset.pkl'), 'wb') as f:
             pickle.dump(self._todict(), f, pickle.HIGHEST_PROTOCOL)
 

--- a/sima/imaging.py
+++ b/sima/imaging.py
@@ -166,6 +166,8 @@ class ImagingDataset(object):
         del self._frame_shape
         del self._num_frames
         del self._num_sequences
+        del self._time_averages
+        # TODO: Delete time_averages.pkl? Is that too aggressive?
         self._sequences = sequences
 
     @property
@@ -241,6 +243,8 @@ class ImagingDataset(object):
 
     @property
     def time_averages(self):
+        if hasattr(self, '_time_averages'):
+            return self._time_averages
         if self.savedir is not None:
             try:
                 with open(join(self.savedir, 'time_averages.pkl'),
@@ -254,7 +258,9 @@ class ImagingDataset(object):
                 # Make sure this is a numpy array and if not just re-calculate
                 # the time averages.
                 if isinstance(time_averages, np.ndarray):
-                    return time_averages
+                    self._time_averages = time_averages
+                    return self._time_averages
+
         sums = np.zeros(self.frame_shape)
         counts = np.zeros(self.frame_shape)
         for frame in it.chain.from_iterable(self):
@@ -264,7 +270,8 @@ class ImagingDataset(object):
         if self.savedir is not None and not self._read_only:
             with open(join(self.savedir, 'time_averages.pkl'), 'wb') as f:
                 pickle.dump(averages, f, pickle.HIGHEST_PROTOCOL)
-        return averages
+        self._time_averages = averages
+        return self._time_averages
 
     @property
     def ROIs(self):

--- a/sima/imaging.py
+++ b/sima/imaging.py
@@ -105,7 +105,10 @@ class ImagingDataset(object):
             with open(join(savedir, 'dataset.pkl'), 'rb') as f:
                 data = pickle.load(f)
             if 'sequences' in data:
-                raise ImportError('Old version')
+                # 1.0.0-dev sets stored sequences in dataset.pkl. Without this
+                # check a later call to ImagingDataset.sequences will fail.
+                # Remove in future version.
+                raise ImportError('Old 1.0.0-dev dataset')
             self._channel_names = data.pop('channel_names', None)
             self._savedir = savedir
             try:

--- a/sima/imaging.py
+++ b/sima/imaging.py
@@ -163,10 +163,22 @@ class ImagingDataset(object):
 
     @sequences.setter
     def sequences(self, sequences):
-        del self._frame_shape
-        del self._num_frames
-        del self._num_sequences
-        del self._time_averages
+        try:
+            del self._frame_shape
+        except AttributeError:
+            pass
+        try:
+            del self._num_frames
+        except AttributeError:
+            pass
+        try:
+            del self._num_sequences
+        except AttributeError:
+            pass
+        try:
+            del self._time_averages
+        except AttributeError:
+            pass
         # TODO: Delete time_averages.pkl? Is that too aggressive?
         self._sequences = sequences
 
@@ -221,7 +233,8 @@ class ImagingDataset(object):
             except OSError as exc:
                 if exc.errno == errno.EEXIST and os.path.isdir(savedir):
                     overwrite = strtobool(
-                        raw_input("Overwrite existing directory? "))
+                        raw_input("Overwrite existing directory ({})? ".format(
+                            savedir)))
                     # Note: This will overwrite dataset.pkl but will leave
                     #       all other files in the directory intact
                     if overwrite:


### PR DESCRIPTION
The goal of this refactorization is to only load data as needed, which removes unnecessary data transfer when datasets are accessed remotely. There should be no noticeable difference with local datasets, but if you don't actually need to iterate over the sequences of an ImagingDatasets, load times should be much faster.

Resolves Issue #104 

Major change:
- sequence data is pulled out of dataset.pkl in to sequences.pkl
- sequences, frame_shape, num_frames, num_sequences are now all properties instead of attributes and are initialized at load if stored in dataset.pkl (see below), or calculated as needed.

Minor changes:
- num_sequences and frame_shape are now saved in dataset.pkl
- time_averages is now saved in the object, so you do not need to re-read the time_averages.pkl file every time you call ImagingDataset.time_averages

Also:
- When prompting to overwrite a SIMA directory, the directory is now printed with the prompt
- A few bug fixes for ellipse ROIs in ROI_Buddy
- ROI_Buddy code cleanup

NOTE: Currently an ImportError is explicitly thrown if you try to load a 1.0.0.dev dataset, not sure if there is a better way to handle this.

I have a convert script that will convert SIMA 1.0.0.dev sets to this new format. I'm not going to put it in the repo, but I can pass it around if needed.
