### PR TITLE
Bug fix to maintain channel names when slicing a dataset.

### DIFF
--- a/sima/imaging.py
+++ b/sima/imaging.py
@@ -157,7 +157,8 @@ class ImagingDataset(object):
             seq_indices = slice(seq_indices, seq_indices + 1)
         sequences = [seq[tuple(indices)] for seq in self.sequences][
             seq_indices]
-        return ImagingDataset(sequences, None)
+        return ImagingDataset(
+            sequences, None, channel_names=self.channel_names)
 
     @property
     def sequences(self):
@@ -251,8 +252,8 @@ class ImagingDataset(object):
                     overwrite = strtobool(
                         input("Overwrite existing directory ({})? ".format(
                             savedir)))
-                    # Note: This will overwrite dataset.pkl but will leave
-                    #       all other files in the directory intact
+                    # Note: This will overwrite dataset.pkl and sequences.pkl
+                    # but will leave all other files in the directory intact
                     if overwrite:
                         self._savedir = savedir
                     else:

--- a/sima/sequence.py
+++ b/sima/sequence.py
@@ -954,6 +954,9 @@ class _IndexedSequence(_WrapperSequence):
                 # memory.
                 yield np.copy(self._base._get_frame(t)[self._indices[1:]])
         except NotImplementedError:
+            if self._indices[0].step < 0:
+                raise NotImplementedError(
+                    'Iterating backwards not supported by the base class')
             idx = 0
             for t, frame in enumerate(self._base):
                 try:


### PR DESCRIPTION
Updated note on overwriting a saved dataset
Added check in sliced sequence wrapper to raise a meaningful exception if you try to iterate backwards over certain sequence types.