### PR TITLE
Force a check of the saved time_averages when converting from 0.x to 1.x

### DIFF
--- a/sima/misc/convert.py
+++ b/sima/misc/convert.py
@@ -177,4 +177,7 @@ def _0_to_1(source, target=None):
         target = source
 
     ds = _load_version0(source)
+    # Load the time_averages to force a check for an old version and re-calc if
+    # necessary
+    ds.time_averages
     ds.save(target)


### PR DESCRIPTION
Old 0.x sets (not sure if all versions were like this) had a different format for time_averages.pkl. This is now checked by a call to dataset.time_averages and if necessary, new time_averages are re-calculated and saved.

This will now force this check when converting 0.x to 1.x datasets.