### PR TITLE
 Segmentation refactoring and 3D STICA

### DIFF
--- a/sima/segment/__init__.py
+++ b/sima/segment/__init__.py
@@ -5,7 +5,8 @@ from .segment import (
     ROIFilter,
     PostProcessingStep,
     SmoothROIBoundaries,
-    RemoveOverlapping,
+    MergeOverlapping,
+    SparseROIsFromMasks,
 )
 from .stica import STICA
 from .ca1pc import (

--- a/sima/segment/__init__.py
+++ b/sima/segment/__init__.py
@@ -4,6 +4,8 @@ from .segment import (
     PlaneWiseSegmentation,
     ROIFilter,
     PostProcessingStep,
+    SmoothROIBoundaries,
+    RemoveOverlapping,
 )
 from .stica import STICA
 from .ca1pc import (

--- a/sima/segment/normcut.py
+++ b/sima/segment/normcut.py
@@ -249,7 +249,7 @@ def _direction(vects, weights=None):
         vects_ = vects
     else:
         vects_ = vects * weights
-    return (vects_.T / np.sqrt((vects_ ** 2).sum(axis=2).T)).T
+    return (vects_.T / np.sqrt((vects_ ** 2).sum(axis=-1).T)).T
 
 
 def _offset_corrs(dataset, pixel_pairs, channel=0, method='EM',
@@ -293,7 +293,7 @@ def _offset_corrs(dataset, pixel_pairs, channel=0, method='EM',
         oPC_vars, oPCs, _ = oPCA.dataset_opca(dataset, channel, num_pcs, path,
                                               verbose=verbose)
         weights = np.sqrt(np.maximum(0, oPC_vars))
-        D = _direction(oPCs, weights)
+        D = _direction(oPCs[0], weights)  # TODO: Generalize to 3D datasets
         return {
             ((u, v), (w, x)): np.dot(D[u, v, :], D[w, x, :])
             for u, v, w, x in pixel_pairs

--- a/sima/segment/normcut.py
+++ b/sima/segment/normcut.py
@@ -244,73 +244,6 @@ class AffinityMatrixMethod(with_metaclass(abc.ABCMeta, object)):
         return
 
 
-class DatasetIterable(object):
-
-    def __init__(self, dataset, channel):
-        self.dataset = dataset
-        self.channel = sima.misc.resolve_channels(
-            channel, dataset.channel_names)
-        self.means = dataset.time_averages[..., self.channel].reshape(-1)
-
-    def __iter__(self):
-        for cycle in self.dataset:
-            for frame in cycle:
-                yield np.nan_to_num(
-                    frame[..., self.channel].reshape(-1) - self.means)
-        raise StopIteration
-
-
-def _OPCA(dataset, ch=0, num_pcs=75, path=None, verbose=False):
-    """Perform offset principal component analysis on the dataset.
-
-    Parameters
-    ----------
-    dataset : ImagingDataset
-        The dataset to which the offset PCA will be applied.
-    channel : int, optional
-        The index of the channel whose signals are used. Defaults
-        to using the first channel.
-    num_pcs : int, optional
-        The number of PCs to calculate. Default is 75.
-    path : str
-        Directory for saving or loading OPCA results.
-
-    Returns
-    -------
-    oPC_vars : array
-        The offset variance accounted for by each oPC. Shape: num_pcs.
-    oPCs : array
-        The spatial representations of the oPCs.
-        Shape: (num_rows, num_columns, num_pcs).
-    oPC_signals : array
-        The temporal representations of the oPCs.
-        Shape: (num_times, num_pcs).
-    """
-    ret = None
-    if path is not None:
-        try:
-            data = np.load(path)
-        except IOError:
-            pass
-        else:
-            if data['oPC_signals'].shape[1] >= num_pcs:
-                ret = (
-                    data['oPC_vars'][:num_pcs],
-                    data['oPCs'][:, :, :num_pcs],
-                    data['oPC_signals'][:, :num_pcs]
-                )
-            data.close()
-    if ret is not None:
-        return ret
-    shape = dataset.frame_shape[1:3]
-    oPC_vars, oPCs, oPC_signals = oPCA.EM_oPCA(
-        DatasetIterable(dataset, ch), num_pcs=num_pcs, verbose=verbose)
-    oPCs = oPCs.reshape(shape + (-1,))
-    if path is not None:
-        np.savez(path, oPCs=oPCs, oPC_vars=oPC_vars, oPC_signals=oPC_signals)
-    return oPC_vars, oPCs, oPC_signals
-
-
 def _direction(vects, weights=None):
     if weights is None:
         vects_ = vects
@@ -357,8 +290,8 @@ def _offset_corrs(dataset, pixel_pairs, channel=0, method='EM',
                 dataset.savedir, 'opca_' + str(channel) + '.npz')
         else:
             path = None
-        oPC_vars, oPCs, _ = _OPCA(dataset, channel, num_pcs, path,
-                                  verbose=verbose)
+        oPC_vars, oPCs, _ = oPCA.dataset_opca(dataset, channel, num_pcs, path,
+                                              verbose=verbose)
         weights = np.sqrt(np.maximum(0, oPC_vars))
         D = _direction(oPCs, weights)
         return {

--- a/sima/segment/oPCA.py
+++ b/sima/segment/oPCA.py
@@ -228,6 +228,7 @@ def offsetPCA(data, num_pcs=None):
 BELOW IS CODE FOR RUNNING OPCA ON A SIMA DATASET
 """
 
+
 class DatasetIterable(object):
 
     def __init__(self, dataset, channel):

--- a/sima/segment/oPCA.py
+++ b/sima/segment/oPCA.py
@@ -14,6 +14,7 @@ from scipy.linalg import eig, eigh, inv, norm
 from scipy.sparse.linalg import eigsh, eigs
 import warnings
 
+import sima.misc
 from . import _opca
 
 
@@ -221,3 +222,74 @@ def offsetPCA(data, num_pcs=None):
         return _method_1(data, num_pcs)
     else:
         return _method_2(data, num_pcs)
+
+
+"""
+BELOW IS CODE FOR RUNNING OPCA ON A SIMA DATASET
+"""
+
+class DatasetIterable(object):
+
+    def __init__(self, dataset, channel):
+        self.dataset = dataset
+        self.channel = sima.misc.resolve_channels(
+            channel, dataset.channel_names)
+        self.means = dataset.time_averages[..., self.channel].reshape(-1)
+
+    def __iter__(self):
+        for cycle in self.dataset:
+            for frame in cycle:
+                yield np.nan_to_num(
+                    frame[..., self.channel].reshape(-1) - self.means)
+        raise StopIteration
+
+
+def dataset_opca(dataset, ch=0, num_pcs=75, path=None, verbose=False):
+    """Perform offset principal component analysis on the dataset.
+
+    Parameters
+    ----------
+    dataset : ImagingDataset
+        The dataset to which the offset PCA will be applied.
+    channel : int, optional
+        The index of the channel whose signals are used. Defaults
+        to using the first channel.
+    num_pcs : int, optional
+        The number of PCs to calculate. Default is 75.
+    path : str
+        Directory for saving or loading OPCA results.
+
+    Returns
+    -------
+    oPC_vars : array
+        The offset variance accounted for by each oPC. Shape: num_pcs.
+    oPCs : array
+        The spatial representations of the oPCs.
+        Shape: (num_rows, num_columns, num_pcs).
+    oPC_signals : array
+        The temporal representations of the oPCs.
+        Shape: (num_times, num_pcs).
+    """
+    ret = None
+    if path is not None:
+        try:
+            data = np.load(path)
+        except IOError:
+            pass
+        else:
+            if data['oPC_signals'].shape[1] >= num_pcs:
+                ret = (
+                    data['oPC_vars'][:num_pcs],
+                    data['oPCs'][:, :, :num_pcs],
+                    data['oPC_signals'][:, :num_pcs]
+                )
+            data.close()
+    if ret is not None:
+        return ret
+    shape = dataset.frame_shape[1:3]
+    oPC_vars, oPCs, oPC_signals = EM_oPCA(
+        DatasetIterable(dataset, ch), num_pcs=num_pcs, verbose=verbose)
+    oPCs = oPCs.reshape(shape + (-1,))
+    if path is not None:
+        np.savez(path, oPCs=oPCs, oPC_vars=oPC_vars, oPC_signals=oPC_signals)
+    return oPC_vars, oPCs, oPC_signals

--- a/sima/segment/oPCA.py
+++ b/sima/segment/oPCA.py
@@ -286,10 +286,9 @@ def dataset_opca(dataset, ch=0, num_pcs=75, path=None, verbose=False):
             data.close()
     if ret is not None:
         return ret
-    shape = dataset.frame_shape[1:3]
     oPC_vars, oPCs, oPC_signals = EM_oPCA(
         DatasetIterable(dataset, ch), num_pcs=num_pcs, verbose=verbose)
-    oPCs = oPCs.reshape(shape + (-1,))
+    oPCs = oPCs.reshape(dataset.frame_shape[:3] + (-1,))
     if path is not None:
         np.savez(path, oPCs=oPCs, oPC_vars=oPC_vars, oPC_signals=oPC_signals)
     return oPC_vars, oPCs, oPC_signals

--- a/sima/segment/stica.py
+++ b/sima/segment/stica.py
@@ -20,7 +20,7 @@ from .segment import (
     _smooth_roi,
     _check_single_plane,
 )
-from .normcut import _OPCA
+from . import oPCA
 from sklearn.decomposition import FastICA
 from sima.ROI import ROI, ROIList
 
@@ -345,14 +345,10 @@ class STICA(SegmentationStrategy):
         components = self._params['components']
         if isinstance(components, int):
             components = list(range(components))
-        _, space_pcs, time_pcs = _OPCA(
+        _, space_pcs, time_pcs = oPCA.dataset_opca(
             dataset, channel, components[-1] + 1, path=pca_path)
         space_pcs = np.real(space_pcs.reshape(
             dataset.frame_shape[1:3] + (space_pcs.shape[2],)))
-        space_pcs = np.array(
-            [space_pcs[:, :, i] for i in components]).transpose((1, 2, 0))
-        time_pcs = np.array([time_pcs[:, i] for i in components]
-                            ).transpose((1, 0))
 
         if self._params['verbose']:
             print('performing ICA...')

--- a/sima/segment/stica.py
+++ b/sima/segment/stica.py
@@ -61,7 +61,7 @@ def _stica(space_pcs, time_pcs, mu=0.01, n_components=30, path=None):
         except IOError:
             pass
         else:
-            if data['st_components'].shape[2] == n_components and \
+            if data['st_components'].shape[-1] == n_components and \
                     data['mu'].item() == mu and \
                     data['num_pcs'] == time_pcs.shape[1]:
                 ret = data['st_components']
@@ -89,23 +89,14 @@ def _stica(space_pcs, time_pcs, mu=0.01, n_components=30, path=None):
     st_components = np.real(np.array(ica.fit_transform(y)))
 
     # pull out the spacial portion of the st_components
-    st_components = \
-        st_components[:(space_pcs.shape[0] * space_pcs.shape[1]), :]
-    st_components = st_components.reshape(space_pcs.shape[0],
-                                          space_pcs.shape[1],
-                                          st_components.shape[1])
-
-    # normalize the ica results
-    for i in range(st_components.shape[2]):
-        st_component = st_components[:, :, i]
-        st_component = abs(st_component - np.mean(st_component))
-        st_component = old_div(st_component, np.max(st_component))
-        st_components[:, :, i] = st_component
+    st_components = st_components[:np.prod(space_pcs.shape[:-1]), :]
+    st_components = st_components.reshape(
+        space_pcs.shape[:-1] + (st_components.shape[-1],))
 
     # save the ica components if a path has been provided
     if path is not None:
         np.savez(path, st_components=st_components, mu=mu,
-                 num_pcs=time_pcs.shape[1])
+                 num_pcs=time_pcs.shape[-1])
 
     return st_components
 

--- a/sima/segment/stica.py
+++ b/sima/segment/stica.py
@@ -11,10 +11,7 @@ except ImportError:
     from numpy import nanmean
 
 import sima.misc
-from .segment import (
-    SegmentationStrategy,
-    _check_single_plane,
-)
+from .segment import SegmentationStrategy
 from . import oPCA
 from sklearn.decomposition import FastICA
 from sima.ROI import ROI, ROIList

--- a/sima/segment/tests/test_segment.py
+++ b/sima/segment/tests/test_segment.py
@@ -38,8 +38,9 @@ def test_extract_rois():
 def test_STICA():
     ds = ImagingDataset.load(example_data())
     method = segment.STICA(components=5)
+    method.append(segment.SparseROIsFromMasks(min_size=50, spatial_sep=True))
     method.append(segment.SmoothROIBoundaries(radius=3))
-    method.append(segment.RemoveOverlapping(0.))
+    method.append(segment.MergeOverlapping(0.5))
     ds.segment(method)
 
 

--- a/sima/segment/tests/test_segment.py
+++ b/sima/segment/tests/test_segment.py
@@ -37,7 +37,9 @@ def test_extract_rois():
     LooseVersion(numpy.__version__) < LooseVersion('1.9.0'))
 def test_STICA():
     ds = ImagingDataset.load(example_data())
-    method = segment.STICA(components=5, overlap_per=0.5)
+    method = segment.STICA(components=5)
+    method.append(segment.SmoothROIBoundaries(radius=3))
+    method.append(segment.RemoveOverlapping(0.))
     ds.segment(method)
 
 

--- a/sima/segment/tests/test_segment.py
+++ b/sima/segment/tests/test_segment.py
@@ -38,7 +38,7 @@ def test_extract_rois():
 def test_STICA():
     ds = ImagingDataset.load(example_data())
     method = segment.STICA(components=5)
-    method.append(segment.SparseROIsFromMasks(min_size=50, spatial_sep=True))
+    method.append(segment.SparseROIsFromMasks(min_size=50))
     method.append(segment.SmoothROIBoundaries(radius=3))
     method.append(segment.MergeOverlapping(0.5))
     ds.segment(method)


### PR DESCRIPTION
I refactored the STICA code, in part to make it work with 3D datasets. The original STICA code had a lot of post-processing steps built in, which I have now separated out. Therefore, to run the original implementation of the STICA, you may have to make some changes to your code if you wish to continue using the post-processing:

```python
import sima.segment

method = sima.segment.STICA()
```

should be replaced with the following new code:

```python
import sima.segment

method = sima.segment.STICA()
method.append(sima.segment.SparseROIsFromMasks())
method.append(sima.segment.SparseROIsFromMasks())
method.append(sima.segment.SmoothROIBoundaries())
method.append(sima.segment.MergeOverlapping(threshold=0.5))
```