### PR TITLE
Improved reliability of masked sequences

### DIFF
--- a/sima/sequence.py
+++ b/sima/sequence.py
@@ -875,18 +875,47 @@ class _MaskedSequence(_WrapperSequence):
         for i in masks:
             outer = self._outers[i][1:]
             if len(outer) == 2:  # (zyx, channels)
-                if outer[0] is None:
-                    frame[:, :, :, outer[1]] = np.nan
+                mask, channels = outer
+                if channels is None:
+                    channels = range(frame.shape[-1])
                 else:
-                    frame[:, :, :, outer[1]][outer[0]] = np.nan
-            elif len(outer) == 3:  # (planes, yx, channels)
-                planes = \
-                    range(frame.shape[-1]) if outer[0] is None else outer[0]
-                for p in planes:
-                    if outer[1] is None:
-                        frame[p][:, :, outer[2]] = np.nan
+                    try:
+                        int(channels)
+                    except TypeError:
+                        pass
                     else:
-                        frame[p][:, :, outer[2]][outer[1]] = np.nan
+                        channels = [channels]
+                for c in channels:
+                    if mask is None:
+                        frame[:, :, :, c] = np.nan
+                    else:
+                        frame[mask, c] = np.nan
+            elif len(outer) == 3:  # (planes, yx, channels)
+                planes, mask, channels = outer
+                if planes is None:
+                    planes = range(frame.shape[0])
+                else:
+                    try:
+                        int(planes)
+                    except TypeError:
+                        pass
+                    else:
+                        planes = [planes]
+                if channels is None:
+                    channels = range(frame.shape[-1])
+                else:
+                    try:
+                        int(channels)
+                    except TypeError:
+                        pass
+                    else:
+                        channels = [channels]
+                for p in planes:
+                    for c in channels:
+                        if mask is None:
+                            frame[p, :, :, c] = np.nan
+                        else:
+                            frame[p, mask, c] = np.nan
             else:
                 raise Exception
 

--- a/sima/tests/test_sequence.py
+++ b/sima/tests/test_sequence.py
@@ -16,6 +16,8 @@ from numpy.testing import (
     run_module_suite,
     assert_allclose)
 
+import numpy as np
+
 import sima
 from sima.misc import example_tiffs, example_tiff
 
@@ -41,7 +43,7 @@ class TestSequence(object):
                       [example_tiffs(), example_tiffs()]])
         assert_equal(seq.shape, (3, 4, 173, 173, 2))
 
-    def test__get_frame_tiff(self):
+    def test_get_frame_tiff(self):
         it = iter(self.tiff_seq)
         assert_array_equal(next(it), self.tiff_seq._get_frame(0))
         assert_array_equal(next(it), self.tiff_seq._get_frame(1))
@@ -57,6 +59,136 @@ class TestSequence(object):
     # @dec.knownfailureif(True)
     # def test_export_tiff16(self):
     #     raise NotImplemented
+
+class TestMaskedSequence(object):
+
+    def setup(self):
+        self.tiff_seq = sima.Sequence.create('TIFF', example_tiff(), 2, 2)
+        self.masked_mask = np.zeros((5, 2, 128, 256, 2), dtype=bool)
+
+    def test_no_masks(self):
+        masked = self.tiff_seq.mask([])
+
+        assert_equal(masked.shape, (5, 2, 128, 256, 2))
+        assert_(np.all(np.isfinite(masked)))
+
+    def test_mask_all(self):
+        masked = self.tiff_seq.mask([(None, None, None, None)])
+
+        assert_equal(masked.shape, (5, 2, 128, 256, 2))
+        assert_(np.all(np.isnan(masked)))
+
+    def test_explicit_mask_all(self):
+        mask_all = np.ones((128, 256), dtype=bool)
+        masked = self.tiff_seq.mask([(range(5), range(2), mask_all, range(2))])
+
+        assert_equal(masked.shape, (5, 2, 128, 256, 2))
+        assert_(np.all(np.isnan(masked)))
+
+    def test_explicit_3d_mask_all(self):
+        mask_all = np.ones((2, 128, 256), dtype=bool)
+        masked = self.tiff_seq.mask([(range(5), mask_all, range(2))])
+
+        assert_equal(masked.shape, (5, 2, 128, 256, 2))
+        assert_(np.all(np.isnan(masked)))
+
+    def test_all_1_plane(self):
+        masked = self.tiff_seq.mask([(None, 0, None, None)])
+
+        self.masked_mask[:, 0, :, :, :] = True
+
+        assert_equal(masked.shape, (5, 2, 128, 256, 2))
+        assert_(np.all(np.isnan(masked)[self.masked_mask]))
+        assert_(np.all(np.isfinite(masked)[~self.masked_mask]))
+    
+    def test_all_1_plane_list(self):
+        masked = self.tiff_seq.mask([(None, [0], None, None)])
+
+        self.masked_mask[:, 0, :, :, :] = True
+
+        assert_equal(masked.shape, (5, 2, 128, 256, 2))
+        assert_(np.all(np.isnan(masked)[self.masked_mask]))
+        assert_(np.all(np.isfinite(masked)[~self.masked_mask]))
+
+    def test_all_1_frame(self):
+        masked = self.tiff_seq.mask([(3, None, None, None)])
+
+        self.masked_mask[3, :, :, :, :] = True
+
+        assert_equal(masked.shape, (5, 2, 128, 256, 2))
+        assert_(np.all(np.isnan(masked)[self.masked_mask]))
+        assert_(np.all(np.isfinite(masked)[~self.masked_mask]))
+        
+    def test_all_1_channel(self):
+        masked = self.tiff_seq.mask([(None, None, None, 1)]) 
+
+        self.masked_mask[:, :, :, :, 1] = True
+
+        assert_equal(masked.shape, (5, 2, 128, 256, 2))
+        assert_(np.all(np.isnan(masked)[self.masked_mask]))
+        assert_(np.all(np.isfinite(masked)[~self.masked_mask]))
+
+    def test_all_1_mask(self):
+        frame_mask = np.random.random((128, 256))
+        frame_mask = frame_mask > 0.5
+        masked = self.tiff_seq.mask([(None, None, frame_mask, None)])
+
+        self.masked_mask[:, :, frame_mask, :] = True
+
+        assert_equal(masked.shape, (5, 2, 128, 256, 2))
+        assert_(np.all(np.isnan(masked)[self.masked_mask]))
+        assert_(np.all(np.isfinite(masked)[~self.masked_mask]))
+
+    def test_3d_mask(self):
+        frame_mask = np.random.random((2, 128, 256))
+        frame_mask = frame_mask > 0.5
+        masked = self.tiff_seq.mask([(None, frame_mask, None)])
+
+        self.masked_mask[:, frame_mask, :] = True
+
+        assert_equal(masked.shape, (5, 2, 128, 256, 2))
+        assert_(np.all(np.isnan(masked)[self.masked_mask]))
+        assert_(np.all(np.isfinite(masked)[~self.masked_mask]))
+
+
+    def test_static_and_single_frame_mask(self):
+        frame_mask = np.random.random((128, 256))
+        frame_mask = frame_mask > 0.5
+        static_mask = np.random.random((128, 256))
+        static_mask = static_mask > 0.3
+        masked = self.tiff_seq.mask([(None, None, static_mask, None),
+                                     (2, 1, frame_mask, 0)])
+
+        self.masked_mask[:, :, static_mask, :] = True
+        self.masked_mask[2, 1, frame_mask, 0] = True
+
+        assert_equal(masked.shape, (5, 2, 128, 256, 2))
+        assert_(np.all(np.isnan(masked)[self.masked_mask]))
+        assert_(np.all(np.isfinite(masked)[~self.masked_mask]))
+
+    def test_all_mask_types(self):
+        frame_mask_2d = np.random.random((128, 256))
+        frame_mask_2d = frame_mask_2d > 0.1
+        static_mask_2d = np.random.random((128, 256))
+        static_mask_2d = static_mask_2d > 0.1
+        frame_mask_3d = np.random.random((2, 128, 256))
+        frame_mask_3d = frame_mask_3d > 0.1
+        static_mask_3d = np.random.random((2, 128, 256))
+        static_mask_3d = static_mask_3d > 0.1
+        masked = self.tiff_seq.mask([([1, 3], 0, frame_mask_2d, 1),
+                                     (None, 1, static_mask_2d, 0),
+                                     ([4], frame_mask_3d, [0]),
+                                     (None, static_mask_3d, [1])])
+
+        self.masked_mask[1, 0, frame_mask_2d, 1] = True
+        self.masked_mask[3, 0, frame_mask_2d, 1] = True
+        self.masked_mask[:, 1, static_mask_2d, 0] = True
+        self.masked_mask[4, frame_mask_3d, 0] = True
+        self.masked_mask[:, static_mask_3d, 1] = True
+
+        assert_equal(masked.shape, (5, 2, 128, 256, 2))
+        assert_(np.all(np.isnan(masked)[self.masked_mask]))
+        assert_(np.all(np.isfinite(masked)[~self.masked_mask]))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Masking sequences now works as doc indicates: frames, planes, channels can all be None, a list, or an int. y,x can be None or a mask.
Added thorough tests for all types of masks.