### PR TITLE
Sort glob.glob results when creating TIFFs sequences

### DIFF
--- a/sima/sequence.py
+++ b/sima/sequence.py
@@ -543,7 +543,8 @@ class _Sequence_TIFFs(Sequence):
                 raise ValueError('paths must be a list of list of str')
             # save paths as an array of shape (frames, planes, channels)
             self._paths = np.array(
-                [[sorted(glob.glob(channel)) if isinstance(channel, str) else channel
+                [[sorted(glob.glob(channel))
+                  if isinstance(channel, str) else channel
                   for channel in plane] for plane in paths]
             ).reshape(-1, len(paths), len(paths[0]))
 

--- a/sima/sequence.py
+++ b/sima/sequence.py
@@ -543,7 +543,7 @@ class _Sequence_TIFFs(Sequence):
                 raise ValueError('paths must be a list of list of str')
             # save paths as an array of shape (frames, planes, channels)
             self._paths = np.array(
-                [[glob.glob(channel) if isinstance(channel, str) else channel
+                [[sorted(glob.glob(channel)) if isinstance(channel, str) else channel
                   for channel in plane] for plane in paths]
             ).reshape(-1, len(paths), len(paths[0]))
 


### PR DESCRIPTION
On linux, glob.glob results are unsorted so that the frames within a sequence will be in random order.