### PR TITLE
Escape special characters in figure title if tex is used with mpl

### DIFF
--- a/sima/extract.py
+++ b/sima/extract.py
@@ -211,8 +211,14 @@ def _save_extract_summary(signals, save_directory, rois):
                        right=False, labelbottom=False, labeltop=False,
                        labelleft=False, labelright=False)
 
-        ax.set_title('Extraction summary: {}\n{}\nPlane {}'.format(
-            signals['timestamp'], save_directory, str(plane_idx)))
+        figtitle = 'Extraction summary: {}\n{}\nPlane {}'.format(
+            signals['timestamp'], save_directory, str(plane_idx))
+        if 'text.usetex' in mpl.rcParams.keys() and \
+           mpl.rcParams['text.usetex']:
+            figtitle = figtitle.replace('\\', '\\\\').replace('_', '\_')
+
+        ax.set_title(figtitle)
+
         figs.append(fig)
 
     pp = PdfPages(os.path.join(save_directory, 'extractSummary_{}.pdf'.format(


### PR DESCRIPTION
If `usetex` is set to `true` in matplotlibrc, special characters such as `_` will cause an error when latex encounters them outside of math mode. This patch escapes underscores and backslashes in summary figure titles in case latex is used with matplotlib.