### PR TITLE
recheck min_verts after smoothing ROI Boundaries

### DIFF
--- a/sima/segment/segment.py
+++ b/sima/segment/segment.py
@@ -516,6 +516,10 @@ class _SmoothBoundariesParallel(object):
                 smoothed_coords = np.hstack(
                     (smoothed_coords, plane*np.ones(
                         (smoothed_coords.shape[0], 1))))
+
+                if smoothed_coords.shape[0] < self.min_verts:
+                    smoothed_coords = polygon
+
             else:
                 smoothed_coords = polygon
 


### PR DESCRIPTION
I found a bug in my code. If the tolerance parameter is set too high the approximate_polygon function will return a line (2 points) instead of 3. This causes problems down the line when creating the ROI. Rechecking against min_verts after smoothing fixes this.