### PR TITLE
ensure proper file formats for exporting frames to h5 files

### DIFF
--- a/sima/sequence.py
+++ b/sima/sequence.py
@@ -415,7 +415,7 @@ class Sequence(with_metaclass(ABCMeta, object)):
             save_frames = iter(self)
         for f_idx, frame in enumerate(save_frames):
             if fmt == 'HDF5':
-                output_array[f_idx] = frame
+                output_array[f_idx] = np.nan_to_num(frame).astype('uint16')
             else:
                 for plane_idx, plane in enumerate(frame):
                     for ch_idx, channel in enumerate(np.rollaxis(plane, -1)):
@@ -434,7 +434,8 @@ class Sequence(with_metaclass(ABCMeta, object)):
             for idx, label in enumerate(['t', 'z', 'y', 'x', 'c']):
                 f['imaging'].dims[idx].label = label
             if channel_names is not None:
-                f['imaging'].attrs['channel_names'] = np.array(channel_names)
+                f['imaging'].attrs['channel_names'] = np.array(channel_names,
+                                                               dtype='string')
             f.close()
 
 

--- a/sima/sequence.py
+++ b/sima/sequence.py
@@ -406,7 +406,7 @@ class Sequence(with_metaclass(ABCMeta, object)):
             if not h5py_available:
                 raise ImportError('h5py >= 2.2.1 required')
             f = h5py.File(filenames, 'w')
-            output_array = np.empty(self.shape, dtype='uint16')
+            output_array = np.empty(self.shape, dtype='float32')
             # TODO: change dtype?
 
         if fill_gaps:
@@ -415,7 +415,7 @@ class Sequence(with_metaclass(ABCMeta, object)):
             save_frames = iter(self)
         for f_idx, frame in enumerate(save_frames):
             if fmt == 'HDF5':
-                output_array[f_idx] = np.nan_to_num(frame).astype('uint16')
+                output_array[f_idx] = frame
             else:
                 for plane_idx, plane in enumerate(frame):
                     for ch_idx, channel in enumerate(np.rollaxis(plane, -1)):


### PR DESCRIPTION
on line 418 NaN values need to be removed to frame and it should be downcast to uint16 prior to being written into output array (I think the casting would happen implicitly, but as I understanding it using 'astype' is preferred for downcasting).

'channel_names' on certain datasets appears to be saved as a list of unicode text which was causing error on line 437. Ensure the dtype is string solves the error.