### PR TITLE
Doc improvements

### DIFF
--- a/sima/extract.py
+++ b/sima/extract.py
@@ -333,7 +333,6 @@ def extract_rois(dataset, rois, signal_channel=0, remove_overlap=True,
 
     # Find overlapping pixels
     overlap = _identify_overlapping_pixels(masks)
-    from pudb import set_trace; set_trace()
 
     # Remove pixels that overlap between ROIs
     if remove_overlap:

--- a/sima/extract.py
+++ b/sima/extract.py
@@ -37,7 +37,9 @@ def _demixing_matrix(dataset):
     -------
     array
         Matrix by which the data can be (left) multiplied to be demixed.
+
     """
+
     from mdp.nodes import FastICANode
 
     # Make matrix of the time averaged channels.
@@ -86,6 +88,7 @@ def _roi_extract(inputs):
         image.
 
     """
+
     frame, frame_idx, constants = inputs
 
     def put_back_nans(values, imaged_rois, n_rois):
@@ -243,6 +246,7 @@ def _identify_overlapping_pixels(masks):
         Returns the points that were overlapping
 
     """
+
     master_mask = np.zeros(masks[0].shape, dtype='uint16')
     for mask in masks:
         master_mask += (mask.todense() != 0).astype('uint16')
@@ -267,6 +271,7 @@ def _remove_pixels(masks, pixels_to_remove):
         Returns original masks with overlapping pixels removed
 
     """
+
     new_masks = []
     for mask in masks:
         new_mask = mask.copy().todok()
@@ -287,8 +292,9 @@ def extract_rois(dataset, rois, signal_channel=0, remove_overlap=True,
         The dataset from which signals are to be extracted.
     rois : ROIList
         ROIList of rois to extract
-    signal_channel : int
-        Index of the channel containing the signal to be extracted.
+    signal_channel : string or int, optional
+        Channel containing the signal to be extracted, either an integer
+        index or a name in self.channel_names.
     remove_overlap : bool, optional
         If True, remove any pixels that overlap between masks.
     n_processes : int, optional
@@ -299,18 +305,20 @@ def extract_rois(dataset, rois, signal_channel=0, remove_overlap=True,
         Index of channel to demix from the signal channel. If None, do not
         demix signals.
 
-    Output - dictionary of arrays
+    Returns
     ------
-    raw : array
-    demixed_raw : array
-    _masks : array
-    mean_frame : array
-    overlap : array
-    signal_channel : int
-    rois : list of roi dictionaries
-    timestamp : string
+    signals : dict
+        The extracted signals along with parameters and values calculated
+        during extraction.
+        See sima.ImagingDataset.extract for details of the signals format.
+
+    See also
+    --------
+    sima.ImagingDataset.extract
 
     """
+
+    signal_channel = dataset._resolve_channel(signal_channel)
 
     if n_processes > 1:
         pool = Pool(processes=n_processes)
@@ -325,6 +333,7 @@ def extract_rois(dataset, rois, signal_channel=0, remove_overlap=True,
 
     # Find overlapping pixels
     overlap = _identify_overlapping_pixels(masks)
+    from pudb import set_trace; set_trace()
 
     # Remove pixels that overlap between ROIs
     if remove_overlap:
@@ -440,7 +449,9 @@ def extract_rois(dataset, rois, signal_channel=0, remove_overlap=True,
     def put_back_nan_rois(signals, included_rois, n_rois):
         """Put NaN rows back in the signals file for ROIs that were never
         imaged or entirely overlapped with other ROIs and were removed.
+
         """
+
         final_signals = []
         for cycle_signals in signals:
             signals_idx = 0
@@ -503,14 +514,18 @@ def save_extracted_signals(dataset, rois, save_path=None, label=None,
         dictionary that will be EXTENDED on to the signals dict, so keys in
         metadata will be keys in signals.pkl. No checking is done, so keys
         should not match any generated during extraction, i.e. 'raw', 'rois'
-    signal_channel : int, optional
-        Index of channel to extract, defaults to the first channel.
+    signal_channel : string or int, optional
+        Channel containing the signal to be extracted, either an integer
+        index or a name in self.channel_names.
     save_summary : boolean
         If True, additionally save a summary of the extracted ROIs.
     kwargs : dict, optional
         Additional keyword arguments will be pass directly to extract_rois.
 
     """
+
+    signal_channel = dataset._resolve_channel(signal_channel)
+
     if save_path is None:
         save_path = dataset.savedir
     if save_path is None:

--- a/sima/imaging.py
+++ b/sima/imaging.py
@@ -346,6 +346,7 @@ class ImagingDataset(object):
         >>> dataset.add_ROIs(rois, 'from_ImageJ')
 
         """
+
         if self.savedir is None:
             raise Exception('Cannot add ROIs unless savedir is set.')
         ROIs.save(join(self.savedir, 'rois.pkl'), label)
@@ -537,7 +538,9 @@ class ImagingDataset(object):
         scale_values : bool, optional
             Whether to scale the values to use the full range of the
             output format. Defaults to False.
+
         """
+
         if fmt == 'HDF5':
             if not isinstance(filenames, basestring):
                 raise ValueError(
@@ -600,7 +603,9 @@ class ImagingDataset(object):
         scale_values : bool, optional
             Whether to scale the values to use the full range of the
             output format. Defaults to False.
+
         """
+
         try:
             depth = np.array(filenames).ndim
         except:
@@ -621,13 +626,15 @@ class ImagingDataset(object):
             The name of the file that will store the exported data.
         fmt : {'csv'}, optional
             The export format. Currently, only 'csv' export is available.
-        channel : string or int
+        channel : string or int, optional
             The channel from which to export signals, either an integer
             index or a string in self.channel_names.
         signals_label : str, optional
             The label of the extracted signal set to use. By default,
             the most recently extracted signals are used.
+
         """
+
         try:
             csvfile = open(path, 'w', newline='')
         except TypeError:  # Python 2
@@ -668,7 +675,7 @@ class ImagingDataset(object):
             ROIList of rois to extract
         signal_channel : string or int, optional
             Channel containing the signal to be extracted, either an integer
-            index or a name in self.channel_names
+            index or a name in self.channel_names.
         label : string or None, optional
             Text label to describe this extraction, if None defaults to a
             timestamp.
@@ -686,12 +693,33 @@ class ImagingDataset(object):
 
         Return
         ------
-        dict of arrays
-            Keys: raw, demixed_raw, mean_frame, overlap, signal_channel, rois,
-            timestamp
+        signals: dict
+            The extracted signals along with parameters and values calculated
+            during extraction.
+            Contains the following keys:
+                raw, demixed_raw : list of arrays
+                    The raw/demixed extracted signal. List of length
+                    num_sequences, each element is an array of shape
+                    (num_ROIs, num_frames).
+                mean_frame : array
+                    Time-averaged mean frame of entire dataset.
+                overlap : tuple of arrays
+                    Tuple of (rows, cols) such that zip(*overlap) returns
+                    row, col pairs of pixel coordinates that are in more than
+                    one mask. Note: coordinates are for the **flattened**
+                    image, so 'rows' is always 0s.
+                signal_channel : int
+                    The index of the channel that was extracted.
+                rois : list of dict
+                    All the ROIs used for the extraction with the order matched
+                    to the order of the rows in 'raw'.
+                    See sima.ROI.todict for details of dictionary format.
+                timestamp : string
+                    Date and time of extraction in '%Y-%m-%d-%Hh%Mm%Ss' format
 
         See also
         --------
+        sima.ROI.ROI
         sima.ROI.ROIList
 
         """
@@ -748,7 +776,9 @@ class ImagingDataset(object):
         -------
         ROIs : sima.ROI.ROIList
             The segmented regions of interest.
+
         """
+
         rois = strategy.segment(self)
         if self.savedir is not None:
             rois.save(join(self.savedir, 'rois.pkl'), label)
@@ -764,6 +794,7 @@ class ImagingDataset(object):
             string in self.channel_names
 
         """
+
         channel = self._resolve_channel(channel)
         try:
             with open(join(self.savedir, 'signals_{}.pkl'.format(channel)),
@@ -779,7 +810,7 @@ class ImagingDataset(object):
 
         Parameters
         ----------
-        channel : int, optional
+        channel : string or int, optional
             The channel to be used for spike inference.
         label : string or None, optional
             Text string indicating the signals from which spikes should be
@@ -822,6 +853,9 @@ class ImagingDataset(object):
           3691-3704.
 
         """
+
+        channel = self._resolve_channel(channel)
+
         import sima.spikes
         all_signals = self.signals(channel)
         if label is None:

--- a/sima/motion/frame_align.py
+++ b/sima/motion/frame_align.py
@@ -45,6 +45,7 @@ class PlaneTranslation2D(motion.MotionEstimationStrategy):
     n_processes : int, optional
         Number of pool processes to spawn to parallelize frame alignment.
         Defaults to 1.
+
     """
 
     def __init__(self, max_displacement=None, method='correlation',
@@ -63,6 +64,7 @@ class PlaneTranslation2D(motion.MotionEstimationStrategy):
         shifts : array
             (2, num_frames*num_cycles)-array of integers giving the
             estimated displacement of each frame
+
         """
         params = self._params
         return _frame_alignment_base(
@@ -90,6 +92,7 @@ def _frame_alignment_base(
     n_processes : int, optional
         Number of pool processes to spawn to parallelize frame alignment.
         Defaults to 1.
+
     """
 
     if n_processes < 1:
@@ -334,6 +337,7 @@ class VolumeTranslation(motion.MotionEstimationStrategy):
         a frame's correlation can have following displacement for the
         displacement to be considered valid. Invalid displacements will be
         masked.
+
     """
 
     def __init__(self, max_displacement=None, criterion=None):
@@ -408,7 +412,9 @@ def shifted_corr(reference, image, displacement):
     Returns
     -------
     correlation : float
+
     """
+
     ref_cuts = np.maximum(0, displacement)
     ref = reference[ref_cuts[0]:, ref_cuts[1]:, ref_cuts[2]:]
     im_cuts = np.maximum(0, -displacement)
@@ -437,7 +443,9 @@ def pyr_down_3d(image, axes=None):
     axes : tuple of int
         The axes along which the downsampling is to occur.  Defaults to
         downsampling on all axes.
+
     """
+
     stdevs = [1.05 if i in axes else 0 for i in range(image.ndim)]
     filtered_image = scipy.ndimage.filters.gaussian_filter(image, stdevs)
     slices = tuple(slice(None, None, 2) if i in axes else slice(None)
@@ -465,7 +473,9 @@ def pyramid_align(reference, target, min_shape=32, max_levels=None,
     min_shape : int or tuple of int
     bounds : ndarray of int
         Shape: (2, D).
+
     """
+
     if max_levels is None:
         max_levels = np.inf
     assert bounds is None or np.all(bounds[0] < bounds[1])

--- a/sima/motion/hmm.py
+++ b/sima/motion/hmm.py
@@ -62,7 +62,9 @@ def _pixel_distribution(dataset, tolerance=0.001, min_frames=1000):
         Mean intensities of each channel.
     var_est :
         Variances of the intensity of each channel.
+
     """
+
     # TODO: separate distributions for each plane
     sums = np.zeros(dataset.frame_shape[-1]).astype(float)
     sum_squares = np.zeros_like(sums)
@@ -105,7 +107,9 @@ def _whole_frame_shifting(dataset, shifts):
     offset : array
         The displacement to add to each shift to align the minimal shift
         with the edge of the corrected image.
+
     """
+
     min_shifts = np.nanmin([np.nanmin(s.reshape(-1, s.shape[-1]), 0)
                             for s in shifts], 0)
     assert np.all(min_shifts == 0)
@@ -171,7 +175,9 @@ def _discrete_transition_prob(r, log_transition_probs, n):
     -------
     float
         The discrete transition probability between the two states.
+
     """
+
     def _log_add(a, b):
         """Add two log probabilities to get a new log probability.
 
@@ -217,7 +223,9 @@ def _threshold_gradient(im):
     array
         Binary values indicating whether the magnitude of the gradient is below
         the 10th percentile.  Same size as im.
+ 
     """
+
     if im.shape[0] > 1:
         # Calculate directional relative derivatives
         _, g_x, g_y = np.gradient(np.log(im))
@@ -272,7 +280,9 @@ def _lookup_tables(position_bounds, log_markov_matrix):
     log_markov_matrix_tbl : array
         Lookup table used to find the transition probability of the transitions
         from transition_tbl.
+
     """
+
     position_tbl = np.array(
         list(it.product(*[list(range(m, M))
              for m, M in zip(*position_bounds)])),
@@ -314,7 +324,9 @@ def _backtrace(start_idx, backpointer, states, position_tbl):
     trajectory : array
         The maximum aposteriori trajectory of displacements.
         Shape: (2, len(states))
+
     """
+
     T = len(states)
     dim = len(position_tbl[0])
     i = start_idx
@@ -350,9 +362,7 @@ class _HiddenMarkov(MotionEstimationStrategy):
             self, dataset, references, gains, movement_model,
             min_displacements, max_displacements, pixel_means, pixel_variances,
             max_step=1):
-        """Estimate the MAP trajectory with the Viterbi Algorithm.
-
-        """
+        """Estimate the MAP trajectory with the Viterbi Algorithm."""
         assert references.ndim == 4
         granularity = self._params['granularity']
         scaled_refs = references / gains
@@ -407,7 +417,9 @@ class _HiddenMarkov(MotionEstimationStrategy):
         dict
             The estimated displacements and partial results of motion
             correction.
+
         """
+
         params = self._params
         if params['verbose']:
             print('Estimating model parameters.')
@@ -592,7 +604,9 @@ class MovementModel(object):
         -------
         mov_decay : array
             The per-line decay-term in the AR(1) motion model
+
         """
+
         decay_matrix = np.dot(self._U, np.dot(self._s ** dt, self._U))
         if not np.all(np.isfinite(decay_matrix)):
             raise Exception
@@ -609,7 +623,9 @@ class MovementModel(object):
         -------
         mov_cov : array
             The per-line covariance-term in the AR(1) motion model
+
         """
+
         return self._cov_matrix * dt
 
     def log_transition_matrix(self, max_distance=1, dt=1.):
@@ -622,6 +638,7 @@ class MovementModel(object):
         dt : float
 
         """
+
         cov_matrix = self.cov_matrix(dt)
         assert np.linalg.det(cov_matrix) > 0
 
@@ -779,6 +796,7 @@ def _beam_search(imdata, positions, transitions, references, state_table,
     num_retained : int
 
     """
+
     if state_table.shape[1] != 3:
         raise ValueError
     log_references = np.log(references)

--- a/sima/motion/hmm.py
+++ b/sima/motion/hmm.py
@@ -463,7 +463,7 @@ class HiddenMarkov2D(_HiddenMarkov):
         or granularity='frame'), each plane (1 or 'plane'), each
         row (2 or 'row'), or pixel (3 or 'column'). As well, a separate
         displacement can be calculated for every n consecutive elements
-        (e.g.\ granularity=('row', 8) for every 8 rows).
+        (e.g. granularity=('row', 8) for every 8 rows).
         Defaults to one displacement per row.
     num_states_retained : int, optional
         Number of states to retain at each time step of the HMM.
@@ -478,8 +478,8 @@ class HiddenMarkov2D(_HiddenMarkov):
         How often to reinitialize the hidden Markov model. This can be useful
         if there are long breaks between frames or planes. Parameter values of
         0 or 1 reinitialize the hidden states every frame or plane,
-        respectively.  default, the hidden distribution of positions is never
-        reinitialized during the sequence.
+        respectively.  By default, the hidden distribution of positions is
+        never reinitialized during the sequence.
     verbose : bool, optional
         Whether to print information about progress.
 

--- a/sima/motion/hmm.py
+++ b/sima/motion/hmm.py
@@ -223,7 +223,7 @@ def _threshold_gradient(im):
     array
         Binary values indicating whether the magnitude of the gradient is below
         the 10th percentile.  Same size as im.
- 
+
     """
 
     if im.shape[0] > 1:

--- a/sima/motion/motion.py
+++ b/sima/motion/motion.py
@@ -55,7 +55,9 @@ class MotionEstimationStrategy(with_metaclass(abc.ABCMeta, object)):
         Returns
         -------
         displacements : list of ndarray of int
+
         """
+
         shifts = self._estimate(dataset)
         assert np.any(np.all(x is not np.ma.masked for x in shift)
                       for shift in it.chain.from_iterable(shifts))
@@ -103,7 +105,9 @@ class MotionEstimationStrategy(with_metaclass(abc.ABCMeta, object)):
         -------
         dataset : sima.ImagingDataset
             The motion-corrected dataset.
+
         """
+
         sequences = [s for s in dataset]
         if correction_channels:
             correction_channels = [
@@ -158,6 +162,7 @@ class ResonantCorrection(MotionEstimationStrategy):
         Horizontal displacement to be added to odd rows. Note the
         convention that row 0 (i.e. the "first" row) is considered
         even.
+
     """
 
     def __init__(self, base_strategy, offset=0):

--- a/sima/segment/ca1pc.py
+++ b/sima/segment/ca1pc.py
@@ -36,8 +36,9 @@ class CA1PCNucleus(PostProcessingStep):
     min_cut_size : int, optional
         No ROIs are made from cuts with fewer than min_cut_size pixels.
         Default: 30.
-    channel : int, optional
-        The index of the channel to be used.
+    channel : string or int, optional
+        Channel containing the signal to be segmented, either an integer
+        index or a channel name. Default: 0.
     x_diameter : int, optional
         The estimated x-diameter of the nuclei in pixels
     y_diameter : int, optional
@@ -187,7 +188,8 @@ class PlaneCA1PC(SegmentationStrategy):
     Parameters
     ----------
     channel : int, optional
-        The channel whose signals will be used in the calculations.
+        Channel containing the signal to be segmented, either an integer
+        index or a channel name. Default: 0.
     num_pcs : int, optional
         The number of principle components to be used in the calculations.
         Default: 75.

--- a/sima/segment/normcut.py
+++ b/sima/segment/normcut.py
@@ -56,7 +56,9 @@ def normcut_vectors(affinity_matrix, k):
     -------
     array
         The normcut vectors.  Shape (num_nodes, k).
+
     """
+
     node_degrees = np.array(affinity_matrix.sum(axis=0)).flatten()
     transformation_matrix = diags(np.sqrt(old_div(1., node_degrees)), 0)
     normalized_affinity_matrix = transformation_matrix * affinity_matrix * \
@@ -81,6 +83,7 @@ class CutRegion(object):
         CutRegion.
     shape : tuple
         The shape of the image represented by the graph.
+
     """
 
     def __init__(self, affinity_matrix, indices, shape):
@@ -111,7 +114,9 @@ class CutRegion(object):
         ----------
         cut : ndarray of bool
             True/False indicating one of the segments.
+
         """
+
         node_degrees = self.affinity_matrix.sum(axis=0)
         k = old_div(node_degrees[:, cut].sum(), node_degrees.sum())
         node_degrees = diags(np.array(node_degrees).flatten(), 0)
@@ -129,7 +134,9 @@ class CutRegion(object):
             The regions created by splitting.
         float
             The normalized cut cost.
+
         """
+
         if not cv2_available:
             raise ImportError('OpenCV >= 2.4.8 required')
         tmp_im = np.zeros(self.shape[0] * self.shape[1])
@@ -202,6 +209,7 @@ def itercut(affinity_matrix, shape, max_pen=0.01, min_size=40, max_size=200):
     -------
     list of CutRegion
         The regions produced by the iterative cutting procedure.
+
     """
     cut_cue = [CutRegion(affinity_matrix, np.arange(affinity_matrix.shape[0]),
                          shape)]
@@ -240,6 +248,7 @@ class AffinityMatrixMethod(with_metaclass(abc.ABCMeta, object)):
         -------
         affinities : scipy.sparse.coo_matrix
             The affinities between the image pixels.
+
         """
         return
 
@@ -264,9 +273,9 @@ def _offset_corrs(dataset, pixel_pairs, channel=0, method='EM',
     pixel_pairs : ndarray of int
         The pairs of pixels, indexed ((y0, x0), (y1, x1)) for
         which the correlation is to be calculated.
-    channel : int, optional
-        The channel to be used for estimating the pixel correlations.
-        Defaults to 0.
+    channel : string or int, optional
+        Channel to be used for estimating the pixel correlations, either an
+        integer index or a channel name. Default: 0.
     method : {'EM', 'fast'}, optional
         The method for estimating the correlations. EM uses the EM
         algorithm to perform OPCA. Fast calculates the offset correlations
@@ -283,7 +292,11 @@ def _offset_corrs(dataset, pixel_pairs, channel=0, method='EM',
         A dictionary whose keys are the elements of the pixel_pairs
         input list, and whose values are the calculated offset
         correlations.
+
     """
+
+    channel = sima.misc.resolve_channels(channel, dataset.channel_names)
+
     if method == 'EM':
         if dataset.savedir is not None:
             path = os.path.join(
@@ -335,8 +348,9 @@ class BasicAffinityMatrix(AffinityMatrixMethod):
 
     Parameters
     ----------
-    channel : int, optional
-        The channel whose signals will be used in the calculations.
+    channel : string or int, optional
+        Channel containing the signal to be processed, either an integer
+        index or a channel name. Default: 0.
     max_dist : tuple of int, optional
         Defaults to (2, 2).
     spatial_decay : tuple of int, optional
@@ -345,6 +359,7 @@ class BasicAffinityMatrix(AffinityMatrixMethod):
         The number of principal component to use. Default: 75.
     verbose : bool, optional
         Whether to print progress status. Default: False.
+
     """
 
     def __init__(self, channel=0, max_dist=None, spatial_decay=None,

--- a/sima/segment/oPCA.py
+++ b/sima/segment/oPCA.py
@@ -86,6 +86,7 @@ def EM_oPCA(data, num_pcs, tolerance=0.01, max_iter=1000, verbose=False):
        Information Processing Systems. 1998.
 
     """
+
     for X in (data):
         p = X.size
         break
@@ -156,6 +157,7 @@ def power_iteration_oPCA(data, num_pcs, tolerance=0.01, max_iter=1000):
 
 
     WARNING: INCOMPLETE!!!!!!!!!!!
+
     """
 
     for X in (data):
@@ -216,7 +218,9 @@ def offsetPCA(data, num_pcs=None):
         The calculated OPCs.  Shape: (num_dimensions, num_pcs).
     signals : array
         The signals for each OPC. Shape: (num_observations, num_pcs).
+
     """
+
     # Determine most efficient method of computation.
     if data.shape[0] > data.shape[1]:
         return _method_1(data, num_pcs)
@@ -252,9 +256,9 @@ def dataset_opca(dataset, ch=0, num_pcs=75, path=None, verbose=False):
     ----------
     dataset : ImagingDataset
         The dataset to which the offset PCA will be applied.
-    channel : int, optional
-        The index of the channel whose signals are used. Defaults
-        to using the first channel.
+    ch : string or int, optional
+        Channel containing the signal to be used, either an integer
+        index or a channel name. Default: 0.
     num_pcs : int, optional
         The number of PCs to calculate. Default is 75.
     path : str
@@ -270,7 +274,11 @@ def dataset_opca(dataset, ch=0, num_pcs=75, path=None, verbose=False):
     oPC_signals : array
         The temporal representations of the oPCs.
         Shape: (num_times, num_pcs).
+
     """
+
+    ch = sima.misc.resolve_channels(ch, dataset.channel_names)
+
     num_pcs = min(num_pcs, dataset.num_frames-1,
                   np.prod(dataset.frame_shape[:3]))
     ret = None

--- a/sima/segment/stica.py
+++ b/sima/segment/stica.py
@@ -104,8 +104,9 @@ class STICA(SegmentationStrategy):
 
     Parameters
     ----------
-    channel : int, optional
-        The index of the channel to be used. Default: 0
+    channel : string or int, optional
+        Channel containing the signal to be segmented, either an integer
+        index or a channel name. Default: 0.
     mu : float, optional
         Weighting parameter for the trade off between spatial and temporal
         information. Must be between 0 and 1. Low values give higher

--- a/sima/sequence.py
+++ b/sima/sequence.py
@@ -267,13 +267,11 @@ class Sequence(with_metaclass(ABCMeta, object)):
             and channel, respectively.
             For example, 'tzyxc' indicates that the HDF5 data
             dimensions represent time (t), plane (z), row (y),
-            column(x), and channel (c), respectively.
-            The string 'tyx' indicates data that data for a single
+            column (x), and channel (c), respectively.
+            The string 'tyx' indicates that data for a single
             imaging plane and single channel has been stored in a
             HDF5 dataset with three dimensions representing time (t),
-            column (y), and row (x) respectively.
-            Note that SIMA 0.1.x does not support multiple z-planes,
-            although these will be supported in future versions.
+            column (y), and row (x), respectively.
         group : str, optional
             The HDF5 group containing the imaging data.
             Defaults to using the root group '/'
@@ -354,6 +352,9 @@ class Sequence(with_metaclass(ABCMeta, object)):
         array : numpy.ndarray
             A numpy array of shape (num_frames, num_planes, num_rows,
             num_columns, num_channels)
+        path : str, optional
+            Instead of directly passing in an array, a path to a saved numpy
+            .npy file may be used to initialize the sequence.
 
         """
         if fmt == 'HDF5':

--- a/sima/sequence.py
+++ b/sima/sequence.py
@@ -124,7 +124,9 @@ class Sequence(with_metaclass(ABCMeta, object)):
 
         The yielded structures are numpy arrays of the shape (num_planes,
         num_rows, num_columns, num_channels).
+
         """
+
         for t in range(len(self)):
             yield self._get_frame(t)
 
@@ -141,7 +143,9 @@ class Sequence(with_metaclass(ABCMeta, object)):
         -------
         frame : np.ndarray
             The desired frame of image data.
+
         """
+
         raise NotImplementedError
 
     @abstractmethod
@@ -206,6 +210,7 @@ class Sequence(with_metaclass(ABCMeta, object)):
         >>> masked_seq = seq.mask([(None, mask, 0)])
 
         """
+
         return _MaskedSequence(self, masks)
 
     @staticmethod
@@ -236,6 +241,7 @@ class Sequence(with_metaclass(ABCMeta, object)):
         True
 
         """
+
         return _Joined_Sequence(sequences)
 
     @classmethod
@@ -357,6 +363,7 @@ class Sequence(with_metaclass(ABCMeta, object)):
             .npy file may be used to initialize the sequence.
 
         """
+
         if fmt == 'HDF5':
             return _Sequence_HDF5(*args, **kwargs)
         elif fmt == 'TIFF':
@@ -379,6 +386,7 @@ class Sequence(with_metaclass(ABCMeta, object)):
         True
 
         """
+
         return np.concatenate([np.expand_dims(frame, 0) for frame in self])
 
     def export(self, filenames, fmt='TIFF16', fill_gaps=False,
@@ -401,7 +409,9 @@ class Sequence(with_metaclass(ABCMeta, object)):
             adjacent frames. Default: False.
         channel_names : list of str, optional
             List of labels for the channels to be saved if using HDF5 format.
+
         """
+
         if fmt not in ['TIFF8', 'TIFF16', 'HDF5']:
             raise ValueError('Unrecognized output format.')
         if (fmt in ['TIFF16', 'TIFF8']) and not np.array(filenames).ndim == 2:
@@ -548,6 +558,7 @@ class _Sequence_TIFFs(Sequence):
     paths : list of list of str
         The string paths[i][j] is a Unix style expression for the the
         filenames for plane i and channel j. See glob for details.
+
     """
 
     def __init__(self, paths):
@@ -643,6 +654,7 @@ class _Sequence_HDF5(Sequence):
     Iterable for an HDF5 file containing imaging data.
 
     See sima.Sequence.create() for details.
+
     """
 
     def __init__(self, path, dim_order, group=None, key=None):
@@ -803,7 +815,9 @@ class _MotionCorrectedSequence(_WrapperSequence):
         The _D displacement of each row in the image cycle.
         Shape: (num_frames, num_planes, num_rows, 2).
 
-    This object has the same attributes and methods as the class it wraps."""
+    This object has the same attributes and methods as the class it wraps.
+
+    """
 
     def __init__(self, base, displacements, extent=None):
         super(_MotionCorrectedSequence, self).__init__(base)
@@ -891,7 +905,6 @@ class _MotionCorrectedSequence(_WrapperSequence):
 
 
 class _MaskedSequence(_WrapperSequence):
-
     """Sequence for masking invalid data with NaN's.
 
     Parameters
@@ -1080,7 +1093,9 @@ def _fill_gaps(frame_iter1, frame_iter2):
     ------
     list of array
         The corrected and filled frames.
+
     """
+
     first_obs = next(frame_iter1)
     for frame in frame_iter1:
         for frame_chan, fobs_chan in zip(frame, first_obs):


### PR DESCRIPTION
General doc cleanup.
Channel names and channel indices can be passed in as arguments interchangeably everywhere, docs updated to reflect this.
Documented the contents of the dictionary returned by extraction.
Closes #186 and #167.