### PR TITLE
Minor tweak to speedup poly2mask

### DIFF
--- a/sima/ROI.py
+++ b/sima/ROI.py
@@ -571,8 +571,9 @@ def poly2mask(polygons, im_size):
                           np.arange(int(y_min), np.ceil(y_max)))]
         points_in_poly = list(filter(shifted_poly.contains, points))
         for point in points_in_poly:
-            x = int(point.x)
-            y = int(point.y)
+            xx, yy = point.xy
+            x = int(xx)
+            y = int(yy)
             if 0 <= y < im_size[1] and 0 <= x < im_size[2]:
                 mask[z, y, x] = True
     masks = []

--- a/sima/ROI.py
+++ b/sima/ROI.py
@@ -572,8 +572,8 @@ def poly2mask(polygons, im_size):
         points_in_poly = list(filter(shifted_poly.contains, points))
         for point in points_in_poly:
             xx, yy = point.xy
-            x = int(xx)
-            y = int(yy)
+            x = int(xx[0])
+            y = int(yy[0])
             if 0 <= y < im_size[1] and 0 <= x < im_size[2]:
                 mask[z, y, x] = True
     masks = []


### PR DESCRIPTION
poly2mask is fairly slow at the moment, this helps a little, but isn't the main issue.

I have a new implementation with skimage.draw (http://scikit-image.org/docs/dev/api/skimage.draw.html#polygon) that is ~15x faster, but it seems to handle edges differently so doesn't return identical masks to the current implementation.