### PR TITLE
Allow hdf5 compression for data exported with export_frames

### DIFF
--- a/sima/imaging.py
+++ b/sima/imaging.py
@@ -585,7 +585,7 @@ class ImagingDataset(object):
                 imsave(filename, out)
 
     def export_frames(self, filenames, fmt='TIFF16', fill_gaps=True,
-                      scale_values=False):
+                      scale_values=False, compression=None):
         """Export imaging data from the dataset.
 
         Parameters
@@ -603,6 +603,10 @@ class ImagingDataset(object):
         scale_values : bool, optional
             Whether to scale the values to use the full range of the
             output format. Defaults to False.
+        compression : {None, 'gzip', 'lzf', 'szip'}, optional
+            If not None and 'fmt' is 'HDF5', compress the data with the
+            specified lossless compression filter. See h5py docs for details on
+            each compression filter.
 
         """
 
@@ -615,7 +619,8 @@ class ImagingDataset(object):
         if fmt == 'HDF5' and not np.array(filenames).ndim == 1:
             raise TypeError('Improperly formatted filenames')
         for sequence, fns in zip(self, filenames):
-            sequence.export(fns, fmt, fill_gaps, self.channel_names)
+            sequence.export(
+                fns, fmt, fill_gaps, self.channel_names, compression)
 
     def export_signals(self, path, fmt='csv', channel=0, signals_label=None):
         """Export extracted signals to a file.

--- a/sima/sequence.py
+++ b/sima/sequence.py
@@ -467,7 +467,7 @@ class Sequence(with_metaclass(ABCMeta, object)):
                 f['imaging'].dims[idx].label = label
             if channel_names is not None:
                 f['imaging'].attrs['channel_names'] = np.array(channel_names,
-                                                               dtype='string')
+                                                               dtype='str')
             f.close()
 
 

--- a/sima/sequence.py
+++ b/sima/sequence.py
@@ -466,8 +466,8 @@ class Sequence(with_metaclass(ABCMeta, object)):
             for idx, label in enumerate(['t', 'z', 'y', 'x', 'c']):
                 f['imaging'].dims[idx].label = label
             if channel_names is not None:
-                f['imaging'].attrs['channel_names'] = np.array(channel_names,
-                                                               dtype='str')
+                f['imaging'].attrs['channel_names'] = [
+                    np.string_(s) for s in channel_names]
             f.close()
 
 

--- a/sima/tests/test_sequence.py
+++ b/sima/tests/test_sequence.py
@@ -83,7 +83,7 @@ class TestSequence(object):
             data = np.array(f['imaging'])
 
         assert_array_equal(['t', 'z', 'y', 'x', 'c'], dims)
-        assert_array_equal(['Ch1', 'Ch2'], channel_names)
+        assert_array_equal(np.string_(['Ch1', 'Ch2']), channel_names)
         assert_array_equal(np.array(self.tiff_seq), data)
 
     @dec.skipif(not h5py_available)
@@ -99,7 +99,7 @@ class TestSequence(object):
             data = np.array(f['imaging'])
 
         assert_array_equal(['t', 'z', 'y', 'x', 'c'], dims)
-        assert_array_equal(['Ch1', 'Ch2'], channel_names)
+        assert_array_equal(np.string_(['Ch1', 'Ch2']), channel_names)
         assert_array_equal(np.array(self.tiff_seq), data)
 
     def test_export_tiff8(self):

--- a/sima/tests/test_sequence.py
+++ b/sima/tests/test_sequence.py
@@ -83,7 +83,7 @@ class TestSequence(object):
             data = np.array(f['imaging'])
 
         assert_array_equal(['t', 'z', 'y', 'x', 'c'], dims)
-        assert_array_equal(np.string_(['Ch1', 'Ch2']), channel_names)
+        assert_array_equal(['Ch1', 'Ch2'], channel_names.astype('str'))
         assert_array_equal(np.array(self.tiff_seq), data)
 
     @dec.skipif(not h5py_available)
@@ -99,7 +99,7 @@ class TestSequence(object):
             data = np.array(f['imaging'])
 
         assert_array_equal(['t', 'z', 'y', 'x', 'c'], dims)
-        assert_array_equal(np.string_(['Ch1', 'Ch2']), channel_names)
+        assert_array_equal(['Ch1', 'Ch2'], channel_names.astype('str'))
         assert_array_equal(np.array(self.tiff_seq), data)
 
     def test_export_tiff8(self):

--- a/sima/tests/test_sequence.py
+++ b/sima/tests/test_sequence.py
@@ -18,10 +18,21 @@ from numpy.testing import (
     run_module_suite,
     assert_allclose)
 
+import os
+import shutil
+
 import numpy as np
+from PIL import Image
 
 import sima
 from sima.misc import example_tiffs, example_tiff
+
+try:
+    import h5py
+except ImportError:
+    h5py_available = False
+else:
+    h5py_available = True
 
 
 def setup():
@@ -37,6 +48,16 @@ class TestSequence(object):
     def setup(self):
         self.tiff_seq = sima.Sequence.create('TIFF', example_tiff(), 2, 2)
 
+        self.tmp_dir = os.path.join(os.path.dirname(__file__), 'tmp')
+
+        try:
+            os.mkdir(self.tmp_dir)
+        except:
+            pass
+
+    def teardown(self):
+        shutil.rmtree(self.tmp_dir)
+
     def test_create_tiffs(self):
         seq = sima.Sequence.create(
             'TIFFs', [[example_tiffs(), example_tiffs()],
@@ -50,17 +71,73 @@ class TestSequence(object):
         assert_array_equal(next(it), self.tiff_seq._get_frame(0))
         assert_array_equal(next(it), self.tiff_seq._get_frame(1))
 
-    # @dec.knownfailureif(True)
-    # def test_export_hdf5(self):
-    #     raise NotImplemented
+    @dec.skipif(not h5py_available)
+    def test_export_hdf5(self):
+        self.tiff_seq.export(
+            os.path.join(self.tmp_dir, 'test_export.h5'), fmt='HDF5',
+            fill_gaps=False, channel_names=['Ch1', 'Ch2'], compression=None)
 
-    # @dec.knownfailureif(True)
-    # def test_export_tiff8(self):
-    #     raise NotImplemented
+        with h5py.File(os.path.join(self.tmp_dir, 'test_export.h5'), 'r') as f:
+            dims = [str(dim.label) for dim in f['imaging'].dims]
+            channel_names = f['imaging'].attrs['channel_names']
+            data = np.array(f['imaging'])
 
-    # @dec.knownfailureif(True)
-    # def test_export_tiff16(self):
-    #     raise NotImplemented
+        assert_array_equal(['t', 'z', 'y', 'x', 'c'], dims)
+        assert_array_equal(['Ch1', 'Ch2'], channel_names)
+        assert_array_equal(np.array(self.tiff_seq), data)
+
+    @dec.skipif(not h5py_available)
+    def test_export_commpressed_hdf5(self):
+        self.tiff_seq.export(
+            os.path.join(self.tmp_dir, 'test_export_compressed.h5'),
+            fmt='HDF5', channel_names=['Ch1', 'Ch2'], compression='gzip')
+
+        with h5py.File(os.path.join(
+                self.tmp_dir, 'test_export_compressed.h5'), 'r') as f:
+            dims = [str(dim.label) for dim in f['imaging'].dims]
+            channel_names = f['imaging'].attrs['channel_names']
+            data = np.array(f['imaging'])
+
+        assert_array_equal(['t', 'z', 'y', 'x', 'c'], dims)
+        assert_array_equal(['Ch1', 'Ch2'], channel_names)
+        assert_array_equal(np.array(self.tiff_seq), data)
+
+    def test_export_tiff8(self):
+        filenames = [[os.path.join(
+            self.tmp_dir, 'test_export_tiff8_plane{}_channel{}.tif'.format(
+                plane, channel)) for channel in range(2)]
+            for plane in range(2)]
+
+        self.tiff_seq.export(filenames, fmt='TIFF8', fill_gaps=False)
+
+        data = np.array(self.tiff_seq)
+
+        for plane, plane_files in enumerate(filenames):
+            for channel, channel_file in enumerate(plane_files):
+                with Image.open(channel_file) as f:
+                    for frame in range(5):
+                        f.seek(frame)
+                        assert_array_equal(
+                            np.array(f),
+                            data[frame, plane, :, :, channel].astype('uint8'))
+
+    def test_export_tiff16(self):
+        filenames = [[os.path.join(
+            self.tmp_dir, 'test_export_tiff16_plane{}_channel{}.tif'.format(
+                plane, channel)) for channel in range(2)]
+            for plane in range(2)]
+
+        self.tiff_seq.export(filenames, fmt='TIFF16', fill_gaps=False)
+
+        data = np.array(self.tiff_seq)
+
+        for plane, plane_files in enumerate(filenames):
+            for channel, channel_file in enumerate(plane_files):
+                with Image.open(channel_file) as f:
+                    for frame in range(5):
+                        f.seek(frame)
+                        assert_array_equal(
+                            np.array(f), data[frame, plane, :, :, channel])
 
 
 class TestMotionCorrectedSequence(object):
@@ -95,6 +172,14 @@ class TestMotionCorrectedSequence(object):
             (self.base_seq.shape[-1],)
 
         assert_equal(mc_seq.shape, expected_shape)
+
+    # @dec.knownfailureif(True)
+    # def test_export(self):
+    #     raise NotImplemented
+
+    # @dec.knownfailureif(True)
+    # def test_export_fill_gaps(self):
+    #     raise NotImplemented
 
 
 class TestMaskedSequence(object):


### PR DESCRIPTION
Closes #198

Rewrote Sequence.export for 'HDF5' format to make it more memory-efficient, should now only load 1 frame at a time.

Added test cases for exporting sequences.