### PR TITLE
Fix loading of negative ROI coordinates

### DIFF
--- a/CREDITS.rst
+++ b/CREDITS.rst
@@ -28,6 +28,8 @@ Testing / Bug Fixes
 * Yoshiyuki Yamada
 * Maximilian Hoffmann
 * Erik Flister
+* Scott Lowe
+* Sander Keemink
 
 
 External code

--- a/sima/misc/imagej.py
+++ b/sima/misc/imagej.py
@@ -8,6 +8,7 @@ from builtins import range
 # https://gist.github.com/luispedro/3437255
 #
 # Modified 2014 by Jeffrey Zaremba.
+# Modified 2015 by Scott Lowe (@scottclowe) and Sander Keemink (@swkeemink).
 
 import numpy as np
 from itertools import product
@@ -97,6 +98,17 @@ def read_roi(roi_obj):
         b1 = _get8()
         return (b0 << 8) | b1
 
+    def _get16signed():
+        """Read a signed 16 bit integer from 2 bytes of the roi file object"""
+        b0 = _get8()
+        b1 = _get8()
+        out = (b0 << 8) | b1
+        # This is a signed integer, so need to check if the value is
+        # positive or negative.
+        if b0 > 127:
+            out = out - 65536
+        return out
+
     def _get32():
         """Read 4 bytes from the roi file object"""
         s0 = _get16()
@@ -137,10 +149,10 @@ def read_roi(roi_obj):
         raise ValueError('read_imagej_roi: \
                           ROI type {} not supported'.format(roi_type))
 
-    top = _get16()
-    left = _get16()
-    bottom = _get16()
-    right = _get16()
+    top = _get16signed()
+    left = _get16signed()
+    bottom = _get16signed()
+    right = _get16signed()
     n_coordinates = _get16()
 
     _getfloat()  # x1


### PR DESCRIPTION
The ROI coordinates are stored as signed (not unsigned) integers,
but the `imagej.read_roi` function loading method was only valid
for unsigned integers.

This was causing a problem specifically when ROIs were drawn
outside of the image (which is possible in ImageJ by dragging a
box outside the window edge). In this case, the top or left coordinate
values would be returned as very large positive values.

This problem is fixed, but I don't know which other values in the
ImageJ file are stored as signed as opposed to unsigned integers, so
other values may still be loaded incorrectly.
