### PR TITLE
New sequences

### DIFF
--- a/sima/sequence.py
+++ b/sima/sequence.py
@@ -1038,6 +1038,7 @@ class _MotionCorrectedSequence(_WrapperSequence):
             'extent': self._frame_shape[:3],
         }
 
+
 class _MIPSequence(_WrapperSequence):
     """Sequence for applying a NaN Max along one of the dimensions.
 
@@ -1061,6 +1062,45 @@ class _MIPSequence(_WrapperSequence):
     def __iter__(self):
         for frame in self._base:
             yield np.nanmax(frame, axis=self._axis, keepdims=True)
+
+    @property
+    def shape(self):
+        return self._shape
+
+    def __len__(self):
+        return len(self._base)
+
+    def _todict(self, savedir=None):
+        return {
+            '__class__': self.__class__,
+            'base': self._base._todict(savedir),
+            'axis': self._axis
+        }
+
+
+class _NaNMeanSequence(_WrapperSequence):
+    """Sequence for applying a NaN Mean along one of the dimensions.
+
+    Parameters
+    ----------
+    base : Sequence
+    axis : axis to perform nanmean along
+
+    """
+
+    def __init__(self, base, axis=0):
+        super(_NaNMeanSequence, self).__init__(base)
+        self._axis = axis
+        self._shape = self._base.shape[:axis+1] + (1,) + \
+            self._base.shape[axis+2:]
+
+    def _get_frame(self, t):
+        frame = self._base._get_frame(t)
+        return np.nanmean(frame, axis=self._axis, keepdims=True)
+
+    def __iter__(self):
+        for frame in self._base:
+            yield np.nanmean(frame, axis=self._axis, keepdims=True)
 
     @property
     def shape(self):

--- a/sima/sequence.py
+++ b/sima/sequence.py
@@ -1038,6 +1038,44 @@ class _MotionCorrectedSequence(_WrapperSequence):
             'extent': self._frame_shape[:3],
         }
 
+class _MIPSequence(_WrapperSequence):
+    """Sequence for applying a NaN Max along one of the dimensions.
+
+    Parameters
+    ----------
+    base : Sequence
+    axis : axis to perform nanmean along
+
+    """
+
+    def __init__(self, base, axis=0):
+        super(_MIPSequence, self).__init__(base)
+        self._axis = axis
+        self._shape = self._base.shape[:axis+1] + (1,) + \
+            self._base.shape[axis+2:]
+
+    def _get_frame(self, t):
+        frame = self._base._get_frame(t)
+        return np.nanmax(frame, axis=self._axis, keepdims=True)
+
+    def __iter__(self):
+        for frame in self._base:
+            yield np.nanmax(frame, axis=self._axis, keepdims=True)
+
+    @property
+    def shape(self):
+        return self._shape
+
+    def __len__(self):
+        return len(self._base)
+
+    def _todict(self, savedir=None):
+        return {
+            '__class__': self.__class__,
+            'base': self._base._todict(savedir),
+            'axis': self._axis
+        }
+
 
 class _MaskedSequence(_WrapperSequence):
     """Sequence for masking invalid data with NaN's.

--- a/sima/tests/test_sequence.py
+++ b/sima/tests/test_sequence.py
@@ -317,17 +317,39 @@ class TestSplicedSequence(object):
 
     def setup(self):
         self.tiff_seq = sima.Sequence.create('TIFF', example_tiff(), 2, 2)
-        self.spliced_sequence = sima.sequence._SplicedSequence(self.tiff_seq, [1,3,4])
+        self.spliced_sequence = sima.sequence._SplicedSequence(
+            self.tiff_seq, [1,3,4])
 
     def test_init(self):
         assert_equal(len(self.spliced_sequence), 3)
-        assert_equal(self.tiff_seq._get_frame(1), self.spliced_sequence._get_frame(0))
-        assert_equal(self.tiff_seq._get_frame(4), self.spliced_sequence._get_frame(2))
+        assert_equal(
+            self.tiff_seq._get_frame(1), self.spliced_sequence._get_frame(0))
+        assert_equal(
+            self.tiff_seq._get_frame(4), self.spliced_sequence._get_frame(2))
 
     def test_to_dict(self):
         dict_ = self.spliced_sequence._todict()
         loaded_sequence = dict_.pop('__class__')._from_dict(dict_)
         assert_equal(np.array(loaded_sequence), np.array(self.spliced_sequence))
+
+
+class TestMIPSequence(object):
+
+    def setup(self):
+        self.tiff_seq = sima.Sequence.create('TIFF', example_tiff(), 2, 2)
+        self.mip_sequence = sima.sequence._MIPSequence(self.tiff_seq)
+
+    def test_init(self):
+        assert_equal(len(self.mip_sequence), len(self.tiff_seq))
+        assert_equal(self.mip_sequence.shape[1], 1)
+        assert_equal(
+            np.nanmax(self.tiff_seq._get_frame(1), 0, keepdims=True),
+            self.mip_sequence._get_frame(1))
+
+    def test_to_dict(self):
+        dict_ = self.mip_sequence._todict()
+        loaded_sequence = dict_.pop('__class__')._from_dict(dict_)
+        assert_equal(np.array(loaded_sequence), np.array(self.mip_sequence))
 
 
 if __name__ == "__main__":

--- a/sima/tests/test_sequence.py
+++ b/sima/tests/test_sequence.py
@@ -313,5 +313,22 @@ class TestMaskedSequence(object):
         assert_(np.all(np.isfinite(masked)[~self.masked_mask]))
 
 
+class TestSplicedSequence(object):
+
+    def setup(self):
+        self.tiff_seq = sima.Sequence.create('TIFF', example_tiff(), 2, 2)
+        self.spliced_sequence = sima.sequence._SplicedSequence(self.tiff_seq, [1,3,4])
+
+    def test_init(self):
+        assert_equal(len(self.spliced_sequence), 3)
+        assert_equal(self.tiff_seq._get_frame(1), self.spliced_sequence._get_frame(0))
+        assert_equal(self.tiff_seq._get_frame(4), self.spliced_sequence._get_frame(2))
+
+    def test_to_dict(self):
+        dict_ = self.spliced_sequence._todict()
+        loaded_sequence = dict_.pop('__class__')._from_dict(dict_)
+        assert_equal(np.array(loaded_sequence), np.array(self.spliced_sequence))
+
+
 if __name__ == "__main__":
     run_module_suite()

--- a/sima/tests/test_sequence.py
+++ b/sima/tests/test_sequence.py
@@ -272,7 +272,6 @@ class TestMaskedSequence(object):
         assert_(np.all(np.isnan(masked)[self.masked_mask]))
         assert_(np.all(np.isfinite(masked)[~self.masked_mask]))
 
-
     def test_static_and_single_frame_mask(self):
         frame_mask = np.random.random((128, 256))
         frame_mask = frame_mask > 0.5
@@ -318,7 +317,7 @@ class TestSplicedSequence(object):
     def setup(self):
         self.tiff_seq = sima.Sequence.create('TIFF', example_tiff(), 2, 2)
         self.spliced_sequence = sima.sequence._SplicedSequence(
-            self.tiff_seq, [1,3,4])
+            self.tiff_seq, [1, 3, 4])
 
     def test_init(self):
         assert_equal(len(self.spliced_sequence), 3)
@@ -330,7 +329,8 @@ class TestSplicedSequence(object):
     def test_to_dict(self):
         dict_ = self.spliced_sequence._todict()
         loaded_sequence = dict_.pop('__class__')._from_dict(dict_)
-        assert_equal(np.array(loaded_sequence), np.array(self.spliced_sequence))
+        assert_equal(
+            np.array(loaded_sequence), np.array(self.spliced_sequence))
 
 
 class TestMIPSequence(object):
@@ -350,6 +350,25 @@ class TestMIPSequence(object):
         dict_ = self.mip_sequence._todict()
         loaded_sequence = dict_.pop('__class__')._from_dict(dict_)
         assert_equal(np.array(loaded_sequence), np.array(self.mip_sequence))
+
+
+class TestNaNMeanSequence(object):
+
+    def setup(self):
+        self.tiff_seq = sima.Sequence.create('TIFF', example_tiff(), 2, 2)
+        self.mean_sequence = sima.sequence._NaNMeanSequence(self.tiff_seq)
+
+    def test_init(self):
+        assert_equal(len(self.mean_sequence), len(self.tiff_seq))
+        assert_equal(self.mean_sequence.shape[1], 1)
+        assert_equal(
+            np.nanmean(self.tiff_seq._get_frame(1), 0, keepdims=True),
+            self.mean_sequence._get_frame(1))
+
+    def test_to_dict(self):
+        dict_ = self.mean_sequence._todict()
+        loaded_sequence = dict_.pop('__class__')._from_dict(dict_)
+        assert_equal(np.array(loaded_sequence), np.array(self.mean_sequence))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I've found it convenient to add some wrapper sequences to assist with analysis. Not sure if these should go in sequences.py or some where else

SplicedSequences are useful for looking through a non-consecutive subset of frames of the base sequence (IndexedSequence seems to require a slice). For example when looking through frames identified as having possible motion correction errors.

NaNMean and Sequences are useful for collapsing 3D data to a single plane for visualization or further analysis