### PR TITLE
Check if paths to sequence data refer to same file

### DIFF
--- a/sima/sequence.py
+++ b/sima/sequence.py
@@ -42,6 +42,7 @@ import warnings
 from distutils.version import StrictVersion
 from os.path import (abspath, dirname, join, normpath, normcase, isfile,
                      relpath)
+import filecmp
 from abc import ABCMeta, abstractmethod
 import uuid
 
@@ -1432,6 +1433,9 @@ def _resolve_paths(d, savedir):
         elif len(valid_paths) > 1:
             testfile = list(valid_paths)[0]
             if all(path_compare(testfile, p) for p in valid_paths):
+                valid_paths = set()
+                valid_paths.add(testfile)
+            elif all(filecmp.cmp(testfile, p) for p in valid_paths):
                 valid_paths = set()
                 valid_paths.add(testfile)
             else:


### PR DESCRIPTION
If there are multiple paths to the sequence data, this change will pick the first path if all paths refer to the same file, as determined by a call to filecmp.cmp(), i.e. same creation time, same size, and same mode. This is useful for network shares that are mounted on different paths for different users, such as /home/user1/cifs/file1 vs /home/user2/cifs/file1.