### PR TITLE
Dft mc

### DIFF
--- a/sima/motion/dftreg.py
+++ b/sima/motion/dftreg.py
@@ -129,6 +129,9 @@ class DiscreteFourier2D(motion.MotionEstimationStrategy):
                 raise NotImplementedError("Error: only one colour channel \
                     can be used for DFT motion correction. Using channel 1.")
 
+            # get results into a shape sima likes
+            frame_shifts = np.zeros([len(frames), num_planes, 2])
+
             for plane_idx in range(num_planes):
                 # load into memory... need to pass numpy array to dftreg.
                 # could(should?) rework it to instead accept tiff array
@@ -172,8 +175,7 @@ class DiscreteFourier2D(motion.MotionEstimationStrategy):
                 else:
                     dy, dx = output
 
-                # get results into a shape sima likes
-                frame_shifts = np.zeros([len(frames), num_planes, 2])
+                # add plane shift info
                 for idx, frame in enumerate(sequence):
                     frame_shifts[idx, plane_idx] = [dy[idx], dx[idx]]
             displacements.append(frame_shifts)

--- a/sima/motion/dftreg.py
+++ b/sima/motion/dftreg.py
@@ -123,14 +123,13 @@ class DiscreteFourier2D(motion.MotionEstimationStrategy):
         displacements = []
 
         for sequence in dataset:
-            num_planes = sequence.shape[1]
-            num_channels = sequence.shape[4]
+            num_frames, num_planes, _, _, num_channels = sequence.shape
             if num_channels > 1:
                 raise NotImplementedError("Error: only one colour channel \
                     can be used for DFT motion correction. Using channel 1.")
 
             # get results into a shape sima likes
-            frame_shifts = np.zeros([len(frames), num_planes, 2])
+            frame_shifts = np.zeros([num_frames, num_planes, 2])
 
             for plane_idx in range(num_planes):
                 # load into memory... need to pass numpy array to dftreg.

--- a/sima/motion/motion.py
+++ b/sima/motion/motion.py
@@ -121,6 +121,11 @@ class MotionEstimationStrategy(with_metaclass(abc.ABCMeta, object)):
         else:
             mc_sequences = sequences
         displacements = self.estimate(sima.ImagingDataset(mc_sequences, None))
+
+        # enforce integer displacements
+        displacements = [d if issubclass(d.dtype.type, np.integer) else \
+                         d.round().astype(np.int64) for d in displacements]
+
         disp_dim = displacements[0].shape[-1]
         max_disp = np.ceil(
             np.max(list(it.chain.from_iterable(d.reshape(-1, disp_dim)
@@ -244,7 +249,7 @@ def _observation_counts(raw_shape, displacements, untrimmed_shape):
             x:(x + raw_shape[2])] = 1
     elif displacements.ndim == 2:
         for plane in range(raw_shape[0]):
-            d = list(displacements[plane].round().astype(np.int64))
+            d = list(displacements[plane])
             if len(d) == 2:
                 d = [0] + d
             cnt[plane + d[0],

--- a/sima/motion/motion.py
+++ b/sima/motion/motion.py
@@ -244,7 +244,7 @@ def _observation_counts(raw_shape, displacements, untrimmed_shape):
             x:(x + raw_shape[2])] = 1
     elif displacements.ndim == 2:
         for plane in range(raw_shape[0]):
-            d = list(displacements[plane])
+            d = list(displacements[plane]).round().astype(np.int64))
             if len(d) == 2:
                 d = [0] + d
             cnt[plane + d[0],

--- a/sima/motion/motion.py
+++ b/sima/motion/motion.py
@@ -244,7 +244,7 @@ def _observation_counts(raw_shape, displacements, untrimmed_shape):
             x:(x + raw_shape[2])] = 1
     elif displacements.ndim == 2:
         for plane in range(raw_shape[0]):
-            d = list(displacements[plane]).round().astype(np.int64))
+            d = list(displacements[plane].round().astype(np.int64))
             if len(d) == 2:
                 d = [0] + d
             cnt[plane + d[0],


### PR DESCRIPTION
Convert displacements to integers when using the correct method of MotionEstimationStrategy, which resolves errors encountered when using DiscreteFourier2D (which produces float displacements even when upsample is 1).

Also fixed an error in DiscreteFourier2D encountered with multiplane data, due to the displacement array being re-preallocated with zeros within the plane for loop. 