### PR TITLE
Optionally apply Gaussian blur & Laplacian before dftreg

### DIFF
--- a/sima/motion/motion.py
+++ b/sima/motion/motion.py
@@ -247,9 +247,10 @@ def _observation_counts(raw_shape, displacements, untrimmed_shape):
             d = list(displacements[plane])
             if len(d) == 2:
                 d = [0] + d
+            d = np.round(np.array(d)).astype(int)
             cnt[plane + d[0],
-                d[1]:(d[1] + raw_shape[1]),
-                d[2]:(d[2] + raw_shape[2])] += 1
+                d[1]:(d[1] + int(np.round(raw_shape[1]))),
+                d[2]:(d[2] + int(np.round(raw_shape[2])))] += 1
     elif displacements.ndim == 3:
         if displacements.shape[-1] == 2:
             return mc.observation_counts(raw_shape, displacements,


### PR DESCRIPTION
Following a suggestion by Olivier Dupont-Therrien (Doric Lenses Inc), optionally apply a sequence of Gaussian & Laplacian filter before performing motion correction with `dftreg`. This strategy can eliminate static inhomogeneities such as vignetting from the images, and is particularly useful for 1-photon widefield microendoscope data acquired through a GRIN lens.
Example data:
Raw images without correction:
https://www.dropbox.com/s/pericx3h1jqzppm/20180919_BG0039_sensor0_0000_corr.tif?dl=0
Images with standard dftreg:
https://www.dropbox.com/s/bzl79wofuwy8fzi/20180919_BG0039_sensor0_0000_corr_sima_mc_lp0_final.tiff?dl=0
Images with laplace filter (sigma=8) followed by dftreg:
https://www.dropbox.com/s/r6ng6ycxoxkzfhl/20180919_BG0039_sensor0_0000_corr_sima_mc_lp8_final.tiff?dl=0

Dropbox pw: `laplace`
