### PR TITLE
Fixed citation in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,7 +79,7 @@ resulting publications:
 
   `Kaifosh P, Zaremba J, Danielson N, and Losonczy A. SIMA: Python software for
   analysis of dynamic fluorescence imaging data. Frontiers in Neuroinformatics.
-  2014 Aug 27; 8:77. doi: 10.3389/fninf.2014.00077.
+  2014 Aug 27; 8:77. doi: 10.3389/fninf.2014.00080.
   <http://dx.doi.org/10.3389/fninf.2014.00080>`_
 
 License


### PR DESCRIPTION
The citation to cite SIMA given in the README has a mistake: the doi stated is 10.3389/fninf.2014.00077. But this doi does not exist: http://doi.org/10.3389/fninf.2014.00077

The correct doi (that is, by the way, also stated as the hyperlink), is: 10.3389/fninf.2014.00080. The difference are the last two digits.