### PR TITLE
Make sima run on python 3 and numpy 1.26

### DIFF
--- a/sima/__init__.py
+++ b/sima/__init__.py
@@ -6,7 +6,7 @@ Version 1.3.2"""
 from sima.imaging import ImagingDataset
 from sima.sequence import Sequence
 
-from numpy.testing import Tester
-test = Tester().test
+import numpy.testing as testing
+test = testing.test
 
 __version__ = '1.3.2'

--- a/sima/motion/__init__.py
+++ b/sima/motion/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
-from numpy.testing import Tester
-test = Tester().test
+import numpy.testing as testing
+test = testing.test
 
 from .motion import MotionEstimationStrategy, ResonantCorrection
 from .frame_align import PlaneTranslation2D, VolumeTranslation

--- a/sima/motion/_motion.pyx
+++ b/sima/motion/_motion.pyx
@@ -9,8 +9,8 @@ import cython
 import numpy as np
 cimport numpy as np
 
-INT_TYPE = np.int
-FLOAT_TYPE = np.float
+INT_TYPE = int
+FLOAT_TYPE = float
 ctypedef np.int_t INT_TYPE_t
 ctypedef np.float_t FLOAT_TYPE_t
 

--- a/sima/segment/_opca.pyx
+++ b/sima/segment/_opca.pyx
@@ -11,8 +11,8 @@ cimport numpy as np
 
 # from sima.misc import pairwise
 
-INT_TYPE = np.int
-FLOAT_TYPE = np.float
+INT_TYPE = int
+FLOAT_TYPE = float
 ctypedef np.int_t INT_TYPE_t
 ctypedef np.float_t FLOAT_TYPE_t
 
@@ -38,7 +38,7 @@ def _fast_ocorr(dataset, np.ndarray[INT_TYPE_t, ndim=2] pixel_pairs, channel=0):
             X = np.nan_to_num(frames[0][channel] - time_avg)
             Y = np.nan_to_num(frames[1][channel] - time_avg)
             if not frame_idx % 100:
-                print frame_idx
+                print(frame_idx)
             ostdevs += X * Y
             for pair_idx in range(num_pairs):
                 a0 = pixel_pairs[pair_idx, 0]


### PR DESCRIPTION
Some changes that were required to install sima & pass tests on
MacOS 15.3.1 x86_64
Python 3.13.2 from MacPorts
numpy 1.26.4 from MacPorts
Test results:
```
>>> sima.test()
NumPy version 1.26.4
NumPy relaxed strides checking option: True
NumPy CPU features:  SSE SSE2 SSE3 SSSE3* SSE41* POPCNT* SSE42* AVX* F16C* FMA3* AVX2* AVX512F? AVX512CD? AVX512_KNL? AVX512_SKX? AVX512_CLX? AVX512_CNL? AVX512_ICL?
..........................................................................................................................................                    [100%]
138 passed, 1 deselected in 1.41s
True
```

